### PR TITLE
Monitor fixes

### DIFF
--- a/hermes/hermes.aeriel/hermes/aeriel/serve/__init__.py
+++ b/hermes/hermes.aeriel/hermes/aeriel/serve/__init__.py
@@ -1,1 +1,1 @@
-from .serve import serve
+from .serve import SingularityInstance, serve

--- a/hermes/hermes.aeriel/hermes/aeriel/serve/serve.py
+++ b/hermes/hermes.aeriel/hermes/aeriel/serve/serve.py
@@ -26,12 +26,6 @@ class SingularityInstance:
         return self._instance.name
 
     def run(self, command: str, background: bool = False) -> Optional[str]:
-        command = "/bin/bash -c '{command}'"
-        logging.debug(
-            "Executing command '{}' in singularity instance {}".format(
-                command, self.name
-            )
-        )
         if background and self._thread is not None:
             raise ValueError(
                 "Can't run command '{}' in background, already "
@@ -48,6 +42,12 @@ class SingularityInstance:
             )
             self._thread.start()
         else:
+            logging.debug(
+                "Executing command '{}' in singularity instance {}".format(
+                    command, self.name
+                )
+            )
+            command = ["/bin/bash", "-c", command]
             response = SingularityClient.execute(self._instance, command)
 
             # check if this is being called from the separate
@@ -152,7 +152,7 @@ def serve(
 
     # add in any additional arguments to the server
     if server_args is not None:
-        cmd += " ".join(server_args)
+        cmd += " " + " ".join(server_args)
 
     # if we specified a log file, reroute stdout and stderr
     # to that file (triton primarily uses stderr)

--- a/hermes/hermes.stillwater/hermes/stillwater/monitor.py
+++ b/hermes/hermes.stillwater/hermes/stillwater/monitor.py
@@ -302,9 +302,9 @@ class ServerMonitor(PipelineProcess):
             # to the file in a thread-safe manner
             http = urllib3.PoolManager()
             lock = threading.Lock()
-            with ThreadPoolExecutor(len(self.trackers)) as ex:
+            with ThreadPoolExecutor(len(self.ips)) as ex:
                 args = (http, f, lock)
-                fs = [ex.submit(self.target, i, *args) for i in self.trackers]
+                fs = [ex.submit(self.target, i, *args) for i in self.ips]
 
             # wait until all the threads are done
             # (i.e. self.stopped == True, or an exception

--- a/hermes/hermes.stillwater/hermes/stillwater/monitor.py
+++ b/hermes/hermes.stillwater/hermes/stillwater/monitor.py
@@ -1,20 +1,19 @@
-import logging
 import re
 import sys
 import threading
 import time
-from collections import defaultdict
-from concurrent import futures
-from typing import List, Optional, Sequence, Union
+from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
+from typing import TYPE_CHECKING, Dict, Iterable, List, Union
 
-import requests
 import tritonclient.grpc as triton
+import urllib3
 
 from hermes.stillwater.logging import listener
 from hermes.stillwater.process import PipelineProcess
 
-_uuid_pattern = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
-_process_format = r'(?<=nv_inference_{}_{}\{{)'  # gpu_uuid="GPU-)'
+if TYPE_CHECKING:
+    from io import TextIOWrapper
+
 _processes = [
     "queue",
     "compute_input",
@@ -24,20 +23,12 @@ _processes = [
 ]
 
 
-def _get_re(prefix: str, model: str, version: int):
+def _get_re(process: str, metric: str, model: str, version: int):
     """Build a regex for find the GPU id and value in metrics rows"""
 
-    return re.compile(
-        "".join(
-            [
-                prefix,
-                # f'(?P<gpu_id>{_uuid_pattern})",',
-                f'model="{model}",',
-                rf'version="{version}"\}} ',
-                "(?P<value>[0-9.]+)",
-            ]
-        )
-    )
+    prefix = f"nv_inference_{process}_{metric}"
+    identifier = rf'\{{model="{model}",version="{version}"\}}'
+    return re.compile(f"(?<={prefix}{identifier} )[0-9.]+$")
 
 
 class ServerMonitor(PipelineProcess):
@@ -53,31 +44,22 @@ class ServerMonitor(PipelineProcess):
         - the time at which the metrics are queried
         - the ip address metrics were queried from
         - the model to which this row of metrics apply
-        - the ID of the GPU to which this row of metrics apply
         - the number of inference executions of that model
-            on that GPU which occured since the last query
+            which occured since the last query
         - the time requests spent queueing for inference on
-            that model on that GPU since the last query in
-            microseconds
+            that model since the last query in microseconds
         - the time spent populating the input tensor for
-            that model on that GPU since the last query in
-            microseconds
+            that model since the last query in microseconds
         - the time spent executing the model inference for
-            that model on that GPU since the last query in
-            microseconds
+            that model since the last query in microseconds
         - the time spent populating the model output tensor
-            for that model on that GPU since the last query
-            in microseconds
+            for that model since the last query in microseconds
         - the total time spent executing all inference
-            processes for that model on that GPU since the
-            lsat query in microseconds
+            processes for that model since the last query
+            in microseconds
 
     Ensemble models are implicitly divided into their
-    constituent models for analysis. It's worth noting for
-    now that steps in an ensemble model that neglect to
-    specify a version will use version 1 by default (
-    **NOT** the latest version). This is a known limitation
-    that is in the process of being fixed.
+    constituent models for analysis.
 
     Args:
         model_name:
@@ -92,32 +74,41 @@ class ServerMonitor(PipelineProcess):
         model_version:
             The version of the model whose metrics to query. If
             the specified model is an ensemble model, this will
-            be ignored. Otherwise, if left as `None`, the default
-            version will be 1 (**NOT** the latest version).
+            be ignored. Otherwise, if left as -1, the latest
+            available version of the model will be used.
+        max_request_rate:
+            The maximum rate at which to request metrics from
+            each inference service. The actual rate may be lower
+            due to download and parsing latencies, as well as
+            threading overhead.
+        name:
+            Name to give to this process
+        **kwargs:
+            Additional keyword arguments to pass to the
+            `PipelineProcess` parent class
     """
 
     def __init__(
         self,
         model_name: str,
-        ips: Union[str, Sequence[str]],
+        ips: Union[str, Iterable[str]],
         filename: str,
-        model_version: Optional[int] = None,
-        *args,
+        model_version: int = -1,
+        max_request_rate: float = 10,
         **kwargs,
     ) -> None:
         self.filename = filename
         if isinstance(ips, str):
             ips = [ips]
 
-        self.res = {}
-        self.trackers = {}
-        for ip in ips:
+        # infer the names and versions of the models
+        # we want to be requesting from each deployment
+        self.ips = list(ips)
+        self.models = self.version = None
+        for ip in self.ips:
             # get the config of the model on each IP to
             # figure out which models we need to monitor
-            # TODO: is there a way to get the config without
-            # resorting to the client? This can cause problems
-            # if running on the same node as the client if the
-            # stream has already been established
+            # TODO: make port configurable
             client = triton.InferenceServerClient(f"{ip}:8001")
             config = client.get_model_config(model_name).config
 
@@ -125,190 +116,208 @@ class ServerMonitor(PipelineProcess):
                 # if the specified model is an ensemble model,
                 # then use the config to find the names and
                 # versions of the models that we should monitor
-                models, versions = zip(
-                    *list(
-                        set(
-                            [
-                                (step.model_name, step.model_version)
-                                for step in config.ensemble_scheduling.step
-                            ]
+                steps = config.ensemble_scheduling.step
+                models = [i.model_name for i in steps]
+                versions = [i.model_version for i in steps]
+
+                # make sure a model doesn't appear more than once
+                # TODO: is this necessary? Or was there another
+                # reason for adding this that I'm forgetting?
+                uniques = set(zip(models, versions))
+                models, versions = zip(*list(uniques))
+
+                # now go through and reaggregate our model
+                # names and versions, checking for models
+                # that indicate that they would like to use
+                # the latest version and inferring that version
+                models, versions = [], []
+                for model, version in zip(*list(uniques)):
+                    models.append(model)
+
+                    if version == -1:
+                        metadata = client.get_model_metadata(model)
+                        version = max(map(int, metadata.versions))
+                    versions.append(version)
+
+                versions = [1 if i == -1 else i for i in versions]
+            else:
+                # otherwise just use the provided name and version explicitly,
+                # inferring the latest version if -1 was passed
+                models = [model_name]
+                if model_version == -1:
+                    metadata = client.get_model_metadata(model)
+                    model_version = max(map(int, metadata.versions))
+                versions = [model_version]
+
+            # if we haven't recorded any models or versions for any
+            # ip addresses yet, record them now. Otherwise, ensure
+            # that the names and versions of models are the same
+            # on all deployments. TODO: should this be relaxed?
+            # Presumably the use case in mind here is a fleet of
+            # services all reading from the same centralized
+            # model repository, so there should be no reason
+            # for them to be different
+            if self.models is None:
+                self.models = models
+                self.versions = versions
+            else:
+                if set(self.models) != set(models):
+                    raise ValueError(
+                        "Model names {} on service at address {} "
+                        "don't match up with inferred names {}".format(
+                            ",".join(models), ip, ",".join(self.models)
                         )
                     )
-                )
+                elif set(self.versions) != set(versions):
+                    raise ValueError(
+                        "Model versions {} on service at address {} "
+                        "don't match up with inferred names {}".format(
+                            ",".join(versions), ip, ",".join(self.versions)
+                        )
+                    )
 
-                # use default value of 1 if config step doesn't
-                # specify a version. TODO: this is _NOT_ good
-                # general behavior, since the -1 indicates that
-                # we're supposed to use the latest version
-                versions = [i if i != -1 else 1 for i in versions]
-            else:
-                # otherwise just use the provided name and
-                # version explicitly
-                models = [model_name]
-                versions = [model_version or 1]
+        super().__init__(**kwargs)
+        self.max_request_rate = max_request_rate
 
-            # since Triton metrics are cumulative, for each
-            # IP address, keep track of the most recent value
-            # for each process for each model on each GPU
-            self.trackers[ip] = {}
-            for model, version in zip(models, versions):
-                # get the regex for reading the total number
-                # of inferences performed
-                prefix = _process_format.format("exec", "count")
-                self.res[model] = {"count": _get_re(prefix, model, version)}
-                self.trackers[ip][model] = {"count": {}}
-
-                # for each subprocess, build an re that can collect
-                # the total amount of time spent executing that
-                # particular process in microseconds
-                for process in _processes:
-                    prefix = _process_format.format(process, "duration_us")
-                    self.res[model][process] = _get_re(prefix, model, version)
-                    self.trackers[ip][model][process] = {}
-
-        super().__init__(*args, **kwargs)
-        self.lock = threading.Lock()
-        self._f = None
-
-    def parse_for_ip(self, ip: str) -> List[str]:
+    def parse_for_ip(
+        self, ip: str, http: urllib3.PoolManager, tracker: Dict[str, int]
+    ) -> List[str]:
         # request some metrics data from the given IP
         # and record the time at which we get the response
-        response = requests.get(f"http://{ip}:8002/metrics")
+        # TODO: make port configurable
+        response = http.request("GET", f"http://{ip}:8002/metrics")
         timestamp = time.time()
+        content = response.data.decode()
 
-        # check for HTTP errors then decode the response
-        response.raise_for_status()
-        content = response.content.decode()
- 
         lines = []
-        for model, processes in self.res.items():
-            tracker = self.trackers[ip][model]
-
+        for model, version in zip(self.models, self.versions):
             # for each model, first find out how many times
             # that model was executed on each GPU
-            counts = {}
-            matches = processes["count"].findall(content)
-            gpu_id = "1"
-            # for gpu_id, value in matches:
-            for value in matches:
-                value = int(float(value))
+            count_re = _get_re("exec", "count", model, version)
+            count = count_re.find(content)
+            if count_re is None:
+                # sometimes Triton won't be able to collect metrics,
+                # so raise an error if there's no data available
+                raise ValueError(
+                    "Couldn't find count for model {} version {} "
+                    "on server at IP address {}. Metric service "
+                    "response was:\n{}".format(model, version, ip, content)
+                )
+
+            count = int(float(count))
+            try:
+                last = tracker["count"]
+            except KeyError:
+                # we haven't recorded executions for this
+                # model yet, so there's no diff to record.
+                # Leave this as `None` though so that we
+                # make sure to go through and record the
+                # existing durations for each process
+                diff = None
+            else:
+                # compute the number of inferences executed
+                # since the last request we made
+                diff = count - last
+
+            tracker["count"] = count
+            if diff == 0:
+                # don't bother if no new inferences happened
+                continue
+            elif diff is not None:
+                # if we have new inferences to record, create
+                # a new line to add to our running dataframe
+                line = f"{timestamp},{ip},{model},{diff}"
+            else:
+                line = None
+
+            # now collect the amount of time spent on each subprocess
+            for process in _processes:
+                dur_re = _get_re(process, "duration_us", model, version)
+                duration = int(float(dur_re.find(content)))
+
                 try:
-                    last = tracker["count"][gpu_id]
+                    last = tracker[process]
                 except KeyError:
-                    # we haven't recorded executions for this
-                    # model on this GPU yet, so there's no
-                    # diff to record
+                    # we don't have an entry for this process yet, so
+                    # record one in the `finally` clause but then move on
                     continue
                 else:
-                    # compute the number of inferences executed
-                    # since the last request we made. Only
-                    # record it's nonzero
-                    diff = value - last
-                    if diff > 0:
-                        counts[gpu_id] = diff
+                    # add the duration for this process to our dataframe entry
+                    diff = duration - last
+                    line += "," + str(diff)
                 finally:
-                    # no matter what happens, update our count
-                    # tracker for this model and GPU
-                    tracker["count"][gpu_id] = value
+                    tracker[process] = duration
 
-            # now collect the amount of time spent
-            # on each subprocess for each GPU
-            durs = defaultdict(dict)
-            for process in _processes:
-                matches = processes[process].findall(content)
-                # for gpu_id, value in matches:
-                for value in matches:
-                    value = int(float(value))
-                    try:
-                        last = tracker[process][gpu_id]
-                    except KeyError:
-                        # no data yet for this GPU, so no diff to record
-                        continue
-                    else:
-                        # calculate the total number of microseconds spent
-                        # executing this process since the last request
-                        diff = value - last
-                        durs[gpu_id][process] = diff
-                    finally:
-                        # no matter what happens, update the tracker for
-                        # this model/process/GPU combo
-                        tracker[process][gpu_id] = value
+                tracker[process] = duration
 
-            # now for each update we need to record for each
-            # GPU, create a new line to add to our dataframe
-            start = f"{timestamp},{ip},{model}"
-            for gpu_id, processes in durs.items():
-                try:
-                    count = counts[gpu_id]
-                except KeyError:
-                    # either we didn't have a value to compute
-                    # a diff from, or the diff was 0, so nothing
-                    # to record here
-                    continue
-
-                # complete this row of the dataframe with
-                # GPU ID, count, and duration data
-                line = start + "," + gpu_id + "," + str(count)
-                for process in _processes:
-                    line += "," + str(processes[process])
+            if line is not None:
                 lines.append(line)
         return lines
 
-    def write(self, content: str) -> None:
-        """Thread-safe write of data from a particular IP"""
-
-        if self._f is None:
-            raise ValueError("Must have opened internal file to write")
-
-        with self.lock:
-            self._f.write(content)
-
-    def target(self, ip):
+    def target(
+        self,
+        ip: str,
+        http: urllib3.PoolManager,
+        f: TextIOWrapper,
+        lock: threading.Lock,
+    ) -> None:
         """Thread target for iteratively collecting metrics from a service"""
 
+        # since Triton metrics are cumulative, use a dict
+        # to keep track of the values at each iteration so
+        # that we can record the diffs
+        tracker = {}
         try:
             while not self.stopped:
-                lines = self.parse_for_ip(ip)
+                lines = self.parse_for_ip(ip, http, tracker)
                 if lines:
-                    self.write("\n" + "\n".join(lines))
-                time.sleep(0.1)
+                    with lock:
+                        f.write("\n" + "\n".join(lines))
+                time.sleep(1 / self.max_request_rate)
         except Exception as e:
-            if self.stopped:
-                return
             self.logger.error(f"Encountered error in parsing ip {ip}:\n {e}")
             self.stop()
             raise
 
-    def run(self):
+    def run(self) -> None:
         self.logger = listener.add_process(self)
         exitcode = 0
+        fs = []
         try:
             # open a file for writing and add a csv header to it
-            self._f = open(self.filename, "w")
-            header = "timestamp,ip,model,gpu_id,count,"
-            header += ",".join(_processes)
-            self.write(header)
+            f = open(self.filename, "w")
+            header = "timestamp,ip,model,count," + ",".join(_processes)
+            f.write(header)
 
             # for each IP address, start up a thread that
             # pull the metrics for its own IP and writes
             # to the file in a thread-safe manner
-            with futures.ThreadPoolExecutor(len(self.trackers)) as ex:
-                fs = []
-                for ip in self.trackers.keys():
-                    fs.append(ex.submit(self.target, ip))
+            http = urllib3.PoolManager()
+            lock = threading.Lock()
+            with ThreadPoolExecutor(len(self.trackers)) as ex:
+                args = (http, f, lock)
+                fs = [ex.submit(self.target, i, *args) for i in self.trackers]
 
             # wait until all the threads are done
             # (i.e. self.stopped == True, or an exception
             # occurs on any of the threads)
-            futures.wait(fs, return_when=futures.FIRST_EXCEPTION)
+            result = wait(fs, return_when=FIRST_EXCEPTION)
+
+            # check to see if any of them stopped due to an exception
+            list(result.done[0]).exception()
         except Exception as e:
             self.cleanup(e)
             exitcode = 1
         finally:
+            # stop the threads and wait for them all to finish
             self.stop()
-            self._f.close()
-            self._f = None
+            wait(fs)
 
+            # now close the file now that nothing else is
+            # going to write to it
+            f.close()
+
+            # close the connection to the logger
             self.logger.debug("Target completed")
             listener.queue.close()
             listener.queue.join_thread()

--- a/hermes/hermes.stillwater/poetry.lock
+++ b/hermes/hermes.stillwater/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "atomicwrites"
-version = "1.4.0"
+version = "1.4.1"
 description = "Atomic file writes."
 category = "dev"
 optional = false
@@ -15,9 +15,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
+docs = ["furo", "sphinx", "zope-interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope-interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
@@ -38,7 +38,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "cffi"
-version = "1.15.0"
+version = "1.15.1"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
 optional = false
@@ -46,17 +46,6 @@ python-versions = "*"
 
 [package.dependencies]
 pycparser = "*"
-
-[[package]]
-name = "charset-normalizer"
-version = "2.0.12"
-description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-category = "main"
-optional = false
-python-versions = ">=3.5.0"
-
-[package.extras]
-unicode_backport = ["unicodedata2"]
 
 [[package]]
 name = "colorama"
@@ -94,14 +83,14 @@ setuptools = "*"
 
 [package.extras]
 dnspython = ["dnspython (>=1.16.0,<2.0)", "idna"]
-docs = ["repoze.sphinx.autointerface", "sphinxcontrib-programoutput", "zope.schema"]
+docs = ["repoze-sphinx-autointerface", "sphinxcontrib-programoutput", "zope-schema"]
 monitor = ["psutil (>=5.7.0)"]
-recommended = ["cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "selectors2", "backports.socketpair", "psutil (>=5.7.0)"]
-test = ["requests", "objgraph", "cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "selectors2", "futures", "mock", "backports.socketpair", "contextvars (==2.4)", "coverage (>=5.0)", "coveralls (>=1.7.0)", "psutil (>=5.7.0)"]
+recommended = ["cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "selectors2", "backports-socketpair", "psutil (>=5.7.0)"]
+test = ["requests", "objgraph", "cffi (>=1.12.2)", "dnspython (>=1.16.0,<2.0)", "idna", "selectors2", "futures", "mock", "backports-socketpair", "contextvars (==2.4)", "coverage (>=5.0)", "coveralls (>=1.7.0)", "psutil (>=5.7.0)"]
 
 [[package]]
 name = "geventhttpclient"
-version = "1.5.4"
+version = "1.5.5"
 description = "http client library for gevent"
 category = "main"
 optional = false
@@ -139,14 +128,6 @@ six = ">=1.5.2"
 protobuf = ["grpcio-tools (>=1.41.0)"]
 
 [[package]]
-name = "idna"
-version = "3.3"
-description = "Internationalized Domain Names in Applications (IDNA)"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
@@ -156,7 +137,7 @@ python-versions = "*"
 
 [[package]]
 name = "networkx"
-version = "2.8.4"
+version = "2.8.5"
 description = "Python package for creating and manipulating graphs and networks"
 category = "dev"
 optional = false
@@ -272,33 +253,15 @@ pytest = ">=3"
 
 [[package]]
 name = "python-rapidjson"
-version = "1.6"
+version = "1.8"
 description = "Python wrapper around rapidjson"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "requests"
-version = "2.28.0"
-description = "Python HTTP for Humans."
-category = "main"
-optional = false
-python-versions = ">=3.7, <4"
-
-[package.dependencies]
-certifi = ">=2017.4.17"
-charset-normalizer = ">=2.0.0,<2.1.0"
-idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<1.27"
-
-[package.extras]
-socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
-
-[[package]]
 name = "setuptools"
-version = "62.6.0"
+version = "63.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -306,7 +269,7 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-reredirects", "sphinxcontrib-towncrier", "furo"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-enabler (>=1.0.1)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-enabler (>=1.3)", "pytest-perf", "mock", "flake8-2020", "virtualenv (>=13.0.0)", "wheel", "pip (>=19.1)", "jaraco.envs (>=2.2)", "pytest-xdist", "jaraco.path (>=3.2.0)", "build", "filelock (>=3.4.0)", "pip-run (>=8.8)", "ini2toml[lite] (>=0.9)", "tomli-w (>=1.0.0)", "pytest-black (>=0.3.7)", "pytest-cov", "pytest-mypy (>=0.9.1)"]
 testing-integration = ["pytest", "pytest-xdist", "pytest-enabler", "virtualenv (>=13.0.0)", "tomli", "wheel", "jaraco.path (>=3.2.0)", "jaraco.envs (>=2.2)", "build", "filelock (>=3.4.0)"]
 
 [[package]]
@@ -335,7 +298,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tritonclient"
-version = "2.22.4"
+version = "2.23.0"
 description = "Python client library and utilities for communicating with Triton Inference Server"
 category = "main"
 optional = false
@@ -355,11 +318,11 @@ http = ["geventhttpclient (>=1.4.4)", "numpy (>=1.19.1)", "python-rapidjson (>=0
 
 [[package]]
 name = "urllib3"
-version = "1.26.9"
+version = "1.26.10"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
 [package.extras]
 brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
@@ -367,7 +330,7 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "zope.event"
+name = "zope-event"
 version = "4.5.0"
 description = "Very basic event publishing system"
 category = "main"
@@ -379,10 +342,10 @@ setuptools = "*"
 
 [package.extras]
 docs = ["sphinx"]
-test = ["zope.testrunner"]
+test = ["zope-testrunner"]
 
 [[package]]
-name = "zope.interface"
+name = "zope-interface"
 version = "5.4.0"
 description = "Interfaces for Python"
 category = "main"
@@ -393,19 +356,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 setuptools = "*"
 
 [package.extras]
-docs = ["sphinx", "repoze.sphinx.autointerface"]
-test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
-testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
+docs = ["sphinx", "repoze-sphinx-autointerface"]
+test = ["coverage (>=5.0.3)", "zope-event", "zope-testing"]
+testing = ["coverage (>=5.0.3)", "zope-event", "zope-testing"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "8f9b14cb4400f0464784093d88a5250f78f368abeb7a795cbc816bf53442974a"
+content-hash = "26e6092b1fe3542f89d20aad7cc8f7bb1f45c1ae3fa9b836785fae63f28c5e91"
 
 [metadata.files]
 atomicwrites = [
-    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
-    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+    {file = "atomicwrites-1.4.1.tar.gz", hash = "sha256:81b2c9071a49367a7f770170e5eec8cb66567cfbbc8c73d20ce5ca4a8d71cf11"},
 ]
 attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
@@ -423,6 +385,9 @@ brotli = [
     {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7ee83d3e3a024a9618e5be64648d6d11c37047ac48adff25f12fa4226cf23d1c"},
     {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:19598ecddd8a212aedb1ffa15763dd52a388518c4550e615aed88dc3753c0f0c"},
     {file = "Brotli-1.0.9-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:44bb8ff420c1d19d91d79d8c3574b8954288bdff0273bf788954064d260d7ab0"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e23281b9a08ec338469268f98f194658abfb13658ee98e2b7f85ee9dd06caa91"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3496fc835370da351d37cada4cf744039616a6db7d13c430035e901443a34daa"},
+    {file = "Brotli-1.0.9-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b83bb06a0192cccf1eb8d0a28672a1b79c74c3a8a5f2619625aeb6f28b3a82bb"},
     {file = "Brotli-1.0.9-cp310-cp310-win32.whl", hash = "sha256:26d168aac4aaec9a4394221240e8a5436b5634adc3cd1cdf637f6645cecbf181"},
     {file = "Brotli-1.0.9-cp310-cp310-win_amd64.whl", hash = "sha256:622a231b08899c864eb87e85f81c75e7b9ce05b001e59bbfbf43d4a71f5f32b2"},
     {file = "Brotli-1.0.9-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:c83aa123d56f2e060644427a882a36b3c12db93727ad7a7b9efd7d7f3e9cc2c4"},
@@ -434,12 +399,18 @@ brotli = [
     {file = "Brotli-1.0.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:40d15c79f42e0a2c72892bf407979febd9cf91f36f495ffb333d1d04cebb34e4"},
     {file = "Brotli-1.0.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:93130612b837103e15ac3f9cbacb4613f9e348b58b3aad53721d92e57f96d46a"},
     {file = "Brotli-1.0.9-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:87fdccbb6bb589095f413b1e05734ba492c962b4a45a13ff3408fa44ffe6479b"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:6d847b14f7ea89f6ad3c9e3901d1bc4835f6b390a9c71df999b0162d9bb1e20f"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:495ba7e49c2db22b046a53b469bbecea802efce200dffb69b93dd47397edc9b6"},
+    {file = "Brotli-1.0.9-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:4688c1e42968ba52e57d8670ad2306fe92e0169c6f3af0089be75bbac0c64a3b"},
     {file = "Brotli-1.0.9-cp36-cp36m-win32.whl", hash = "sha256:61a7ee1f13ab913897dac7da44a73c6d44d48a4adff42a5701e3239791c96e14"},
     {file = "Brotli-1.0.9-cp36-cp36m-win_amd64.whl", hash = "sha256:1c48472a6ba3b113452355b9af0a60da5c2ae60477f8feda8346f8fd48e3e87c"},
     {file = "Brotli-1.0.9-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3b78a24b5fd13c03ee2b7b86290ed20efdc95da75a3557cc06811764d5ad1126"},
     {file = "Brotli-1.0.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9d12cf2851759b8de8ca5fde36a59c08210a97ffca0eb94c532ce7b17c6a3d1d"},
     {file = "Brotli-1.0.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6c772d6c0a79ac0f414a9f8947cc407e119b8598de7621f39cacadae3cf57d12"},
     {file = "Brotli-1.0.9-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29d1d350178e5225397e28ea1b7aca3648fcbab546d20e7475805437bfb0a130"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7bbff90b63328013e1e8cb50650ae0b9bac54ffb4be6104378490193cd60f85a"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ec1947eabbaf8e0531e8e899fc1d9876c179fc518989461f5d24e2223395a9e3"},
+    {file = "Brotli-1.0.9-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:12effe280b8ebfd389022aa65114e30407540ccb89b177d3fbc9a4f177c4bd5d"},
     {file = "Brotli-1.0.9-cp37-cp37m-win32.whl", hash = "sha256:f909bbbc433048b499cb9db9e713b5d8d949e8c109a2a548502fb9aa8630f0b1"},
     {file = "Brotli-1.0.9-cp37-cp37m-win_amd64.whl", hash = "sha256:97f715cf371b16ac88b8c19da00029804e20e25f30d80203417255d239f228b5"},
     {file = "Brotli-1.0.9-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e16eb9541f3dd1a3e92b89005e37b1257b157b7256df0e36bd7b33b50be73bcb"},
@@ -447,6 +418,9 @@ brotli = [
     {file = "Brotli-1.0.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b663f1e02de5d0573610756398e44c130add0eb9a3fc912a09665332942a2efb"},
     {file = "Brotli-1.0.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5b6ef7d9f9c38292df3690fe3e302b5b530999fa90014853dcd0d6902fb59f26"},
     {file = "Brotli-1.0.9-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8a674ac10e0a87b683f4fa2b6fa41090edfd686a6524bd8dedbd6138b309175c"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:e2d9e1cbc1b25e22000328702b014227737756f4b5bf5c485ac1d8091ada078b"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:b336c5e9cf03c7be40c47b5fd694c43c9f1358a80ba384a21969e0b4e66a9b17"},
+    {file = "Brotli-1.0.9-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:85f7912459c67eaab2fb854ed2bc1cc25772b300545fe7ed2dc03954da638649"},
     {file = "Brotli-1.0.9-cp38-cp38-win32.whl", hash = "sha256:35a3edbe18e876e596553c4007a087f8bcfd538f19bc116917b3c7522fca0429"},
     {file = "Brotli-1.0.9-cp38-cp38-win_amd64.whl", hash = "sha256:269a5743a393c65db46a7bb982644c67ecba4b8d91b392403ad8a861ba6f495f"},
     {file = "Brotli-1.0.9-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2aad0e0baa04517741c9bb5b07586c642302e5fb3e75319cb62087bd0995ab19"},
@@ -454,6 +428,9 @@ brotli = [
     {file = "Brotli-1.0.9-cp39-cp39-manylinux1_i686.whl", hash = "sha256:16d528a45c2e1909c2798f27f7bf0a3feec1dc9e50948e738b961618e38b6a7b"},
     {file = "Brotli-1.0.9-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:56d027eace784738457437df7331965473f2c0da2c70e1a1f6fdbae5402e0389"},
     {file = "Brotli-1.0.9-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bf919756d25e4114ace16a8ce91eb340eb57a08e2c6950c3cebcbe3dff2a5e7"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:e4c4e92c14a57c9bd4cb4be678c25369bf7a092d55fd0866f759e425b9660806"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e48f4234f2469ed012a98f4b7874e7f7e173c167bed4934912a29e03167cf6b1"},
+    {file = "Brotli-1.0.9-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:9ed4c92a0665002ff8ea852353aeb60d9141eb04109e88928026d3c8a9e5433c"},
     {file = "Brotli-1.0.9-cp39-cp39-win32.whl", hash = "sha256:cfc391f4429ee0a9370aa93d812a52e1fee0f37a81861f4fdd1f4fb28e8547c3"},
     {file = "Brotli-1.0.9-cp39-cp39-win_amd64.whl", hash = "sha256:854c33dad5ba0fbd6ab69185fec8dab89e13cda6b7d191ba111987df74f38761"},
     {file = "Brotli-1.0.9-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:9749a124280a0ada4187a6cfd1ffd35c350fb3af79c706589d98e088c5044267"},
@@ -465,60 +442,70 @@ certifi = [
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
 cffi = [
-    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
-    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
-    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
-    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
-    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
-    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
-    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
-    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
-    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
-    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
-    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
-    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
-    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
-    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
-    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
-    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
-    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
-    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
-    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
-    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
-    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
-    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
-    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
-    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
-    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
-    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
-]
-charset-normalizer = [
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
+    {file = "cffi-1.15.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2"},
+    {file = "cffi-1.15.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914"},
+    {file = "cffi-1.15.1-cp27-cp27m-win32.whl", hash = "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3"},
+    {file = "cffi-1.15.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162"},
+    {file = "cffi-1.15.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21"},
+    {file = "cffi-1.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e"},
+    {file = "cffi-1.15.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01"},
+    {file = "cffi-1.15.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e"},
+    {file = "cffi-1.15.1-cp310-cp310-win32.whl", hash = "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2"},
+    {file = "cffi-1.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac"},
+    {file = "cffi-1.15.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325"},
+    {file = "cffi-1.15.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef"},
+    {file = "cffi-1.15.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8"},
+    {file = "cffi-1.15.1-cp311-cp311-win32.whl", hash = "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d"},
+    {file = "cffi-1.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104"},
+    {file = "cffi-1.15.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405"},
+    {file = "cffi-1.15.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e"},
+    {file = "cffi-1.15.1-cp36-cp36m-win32.whl", hash = "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf"},
+    {file = "cffi-1.15.1-cp36-cp36m-win_amd64.whl", hash = "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497"},
+    {file = "cffi-1.15.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c"},
+    {file = "cffi-1.15.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426"},
+    {file = "cffi-1.15.1-cp37-cp37m-win32.whl", hash = "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9"},
+    {file = "cffi-1.15.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045"},
+    {file = "cffi-1.15.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02"},
+    {file = "cffi-1.15.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192"},
+    {file = "cffi-1.15.1-cp38-cp38-win32.whl", hash = "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314"},
+    {file = "cffi-1.15.1-cp38-cp38-win_amd64.whl", hash = "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585"},
+    {file = "cffi-1.15.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35"},
+    {file = "cffi-1.15.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76"},
+    {file = "cffi-1.15.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3"},
+    {file = "cffi-1.15.1-cp39-cp39-win32.whl", hash = "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee"},
+    {file = "cffi-1.15.1-cp39-cp39-win_amd64.whl", hash = "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c"},
+    {file = "cffi-1.15.1.tar.gz", hash = "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"},
 ]
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
@@ -564,48 +551,48 @@ gevent = [
     {file = "gevent-21.12.0.tar.gz", hash = "sha256:f48b64578c367b91fa793bf8eaaaf4995cb93c8bc45860e473bf868070ad094e"},
 ]
 geventhttpclient = [
-    {file = "geventhttpclient-1.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7eaf8ca9bc220839cf43e4d8c66136f9b75705e82bf5892463ff8203d84c4e7a"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ea80fcc104e9f07d91fa1a2829e5bd75a82911915502246ec97bd7ad58bf785"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:21f76b72c7755b7da4bc9c7a6bfe31eabb98d8439fc2aac71698a6b948c8e919"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a2eff9c1f300b79a2f3628bc25462e3aba429bfe18c25f8a9d31c0bfaf60da"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2f05a1d6849008d3641b93e4e4e243c6302550ac8730e1492b880e1ffc3facb4"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e6c5bd51028094fb0808710e38199e4765d0cc42e591f8385eaed6708295b6a4"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-win32.whl", hash = "sha256:6330e4101fb1980270986dbc7f49120fef20a6fbdad92dcfbf8ad006791f477d"},
-    {file = "geventhttpclient-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:714d5f6816ae158b1623d8f1ee26e6f99cb71c877903ec9ee400c4118ea9834c"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:5eb8cd9ac5540d0144d1a7ca92afb4a6c79ca275eb7464d30d63177dd364b051"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d66ae32e6fc1c75ca024bc0fac2470a48d34e7fe6b7f28e437139ed97fe3eb3b"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:34a3b66876648ec67949bd0024002eeabbae33f46e6466592423d6d8d199492f"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d732263109f1c122a7f028e737c60c2d06715155761fe86d27236d5836e2b4ed"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-win32.whl", hash = "sha256:97f20202fcb0db4e549a6ec683a62b1160e34a7f8e4ac87021da47ff3eddd34c"},
-    {file = "geventhttpclient-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7ef7fc7570da60e63626f853c173aafd70934a084a72253a11b5161bec6dff53"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4bd5e9e96cbb020b7447614969410675286776fcdc809a6bd55651b31b92d37d"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ebea5ef7549116d8054dd0ae4c06f19b544f3d1d831461f92458224b7d0c454"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:db2c3985a016d0a50e573efd08e824546851fbaf90d0a22e3e2fd84f585ffe74"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c1618207bfe1e0531646a607dc0a2e513b36c97184eacd50475993210c0547"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-win32.whl", hash = "sha256:67533de248fd644999599ae5a0026c04f632d92fb4ebb26dd89f42bbb8f4bb48"},
-    {file = "geventhttpclient-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:f7b3162e5b7028503285ff568106b862a128b896231efc7461611acb344ef76c"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5c2f48c8f00015526616a21e41550428608bd20e16f076c88d7d45d11c82d513"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:eb7601162b73e08bcaf778ee466859919fe89f6a1c1f2b13ec2b0d97056bd425"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2de2439839173edec66a551f45a92a8236b85df5b0e7bdd404b5cbd8001edc20"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:412c5624a57db2db43c91e67bd6913a9c6890d7e77a1a8486617319bf74c9b79"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:246e549070c26e97f19e9589d1e364374fffcc710c19b16b744aaab37a82d303"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:92a7a0b9687a1a59de5b79cd9fd8bdf6d4111a3e38983e4f78f9ca0cffaeb72f"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-win32.whl", hash = "sha256:45950e3942afe8707c80ec88689c673b0f7f25e4969233e6e3a459ee9830e4f8"},
-    {file = "geventhttpclient-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:6c53ea0afbb11fd5ab1992313c468088937e789b1452ec8413a1a7d0094e39a0"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:5d09af0e1a0935ff825cd382419b26b0e5ac76bb8a766633226d4f0d828ea48a"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:40b8703ae88b0a5c244623e4a8c987ff800ea757c8085abf2d8a94af8155da04"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:44f8af45306f19bd442ea549287072c13bc69cfac83bb52734c11c2d6f429128"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0f3818c2e59ca91d3325afc55aa43b20d1e45a80cbfd8754a86e7315ef53dad"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bcdf778d08e9164500350bc0a5b9827776997500650674beddc2b8ac09efe930"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f2e70c852c658a59e0fe9e12660550745044d215c946c92058b993dbf76962b9"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-win32.whl", hash = "sha256:044a539f282cd694be785ea3a5b1f8975ff18d36029e3911437963ada32fffa5"},
-    {file = "geventhttpclient-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:3706bbf697eef21c02ed89128381c96c66955f1c93ebf8e0da234d62c64f23be"},
-    {file = "geventhttpclient-1.5.4-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:c41739138e4d94ba400dc287afcc5f8dd350347e6923665d63606cac5a1740b9"},
-    {file = "geventhttpclient-1.5.4-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d71c9cf2c324661d81015ede746045ffcd66bcf9b3c15f1d7830d53124d71ec9"},
-    {file = "geventhttpclient-1.5.4-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6bd2979c31678af985cf0ae54b3983c0924d3a214580265afc7af6a468c22fe5"},
-    {file = "geventhttpclient-1.5.4-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b942822ed77417fe965fde1b9d1a7f60391495e02efa00d0a8cf660a290d9097"},
-    {file = "geventhttpclient-1.5.4-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1554e9bf2de254767983e7eccd580f3330b48b605d48b924c535e299569081f9"},
-    {file = "geventhttpclient-1.5.4.tar.gz", hash = "sha256:008319672b88443c2ab2668c2e8880cd4323b16dac0487b86248fe05638ce028"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:9629b5ce015b8856659bb57193d1e5cf2c0de73ab2e6f7d2a630bcc8d5f211b9"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ad19c5b939cb6075aaaeec2dee2aa42aa29414077f9b3720d659f92ca6ca9889"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:22a0853d809e846d93b2ca06821c897633a6bfe14bc4b0250fb1a38ee83b2030"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63b31eec5840b83571801e3c4880744336e4c048ed8cfcf7019d8dd35c2dd8e1"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5bd4df4b4d57e167e8959fa2126612607c6d4fd5023759d0ecf9820d16c06662"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e28310becf764f3523e13b1a11f530854d77b628e64667246b05dc9e6771e8ab"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-win32.whl", hash = "sha256:128e379f23e45f1133b630b708bb830d99488b2b39384f04b8262e875190d3e9"},
+    {file = "geventhttpclient-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:750dfe6a29078e85ee7fb4fc39df147da5bc80c8a129ed5ac446c288f24fa3f1"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b224d8f34714e2bb2225916271b414e3ebf2f7e1c294c7d63ef400091dccc5eb"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa0b1eee6ac345328b2ce381613a85ef9791e5afd829ef41cf123caa04f3602"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:96361a47228f148f5c4465e8e70ffa4ce2062111ba3fb9f8b47215ae3e7f474d"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f05d70d27dd11315e02735337e7d6de318a73f389a85395d3423d91fb55fa3b9"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-win32.whl", hash = "sha256:ba7f33dd13fa037bd8f8106bf921d48f0d82308355d5572b29873393f33b9511"},
+    {file = "geventhttpclient-1.5.5-cp36-cp36m-win_amd64.whl", hash = "sha256:da832b164f64e6b97b1eb9198c1cd57225a0ec9608289748cda9e151c6722c2d"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:273cc4c3b8ed164e117b6b66fae97da047fea8810dc6b5ef4e9a7481b2eb3f57"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e0daa4819fa32fba8688e54f8e67ece08491595a79cc336f84aca43def2af73"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7d94850a97ba8eefa4a369c3d9607816eb519022eae267d6288d09701691b8d0"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:86b27b36e87e7bc4419df681ffd2267984cd3ba29558555ae79fdc9609392953"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-win32.whl", hash = "sha256:47807a61886bbefbe04cd387570a4cfb952d415f8a5f61217ddfa6fb7ba6a4d4"},
+    {file = "geventhttpclient-1.5.5-cp37-cp37m-win_amd64.whl", hash = "sha256:527efcdeb07c9fc1eb8a85759d7c6696e361e684c22c7ccba3b7b7e6eb9d8aaa"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:ee7bd2c0eea881cf247f12c4362ef0d61623df79768f5ef1c0298e97a1f0c6bf"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0f46912f78d68ef31aa2c86e67a70a079c1418ebd9b04cbb8c097d88ceff721f"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:383949f8d403e30e339cbebe9781c745929d769a8a0470756668fc16156b5605"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:793caf5dfbda63406115cc637814ce8242fd1ba53342da4f89d95bbfc1759d0b"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2f011343a5b4e7799e375c0be8d760405bcaff185dba996c359ef9d541dbc855"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:5d8d8728f87cf56ef351d1315530f31ae8617d0bce45eb4b6e677610ef78a688"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-win32.whl", hash = "sha256:0d5435ad466a4d226d0cc89c69c298c644bbd0af65898a2c1433599189c0a9d3"},
+    {file = "geventhttpclient-1.5.5-cp38-cp38-win_amd64.whl", hash = "sha256:a9f10a0c10cb8a1ecdfe5f034cf4c027c5683edd6f2ee19f83e8d8d4850ccc2a"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:15d6150e9ac9e71edb57341910d4a3740909591d75f885d460045cd1f0fdb8d2"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731bf4f00b3b8c47e7e28b8478501420caf91ca899040c0b9687681272d238ef"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0123ba90c778dff2c89a659bce700ffec4d49e8bf1c8af53de0657435aa4536a"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:641e726eb8ca602f09a1b4588db642d2ddcab589789b7b12ba98d5f058b2ec17"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4929134821c1c74c6b0798e5ff93ea326a3d5e325b6dc3b752f3310d23ae358e"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:02cd47c3f36b7057864478805a725d9b3f574709cf7730f291753bebfd5711ba"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-win32.whl", hash = "sha256:151425e44805c5c396dcedfcba0a164c20065c3eeb5dfb22fb809bf301c98739"},
+    {file = "geventhttpclient-1.5.5-cp39-cp39-win_amd64.whl", hash = "sha256:96d020ffa5cbcd611ee1438925ddf357afded162c3604e867f2b7da16420d589"},
+    {file = "geventhttpclient-1.5.5-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3248eeaecdf54d733b33eb358d76a06728232bd7ea05c71f8950034264e8baa4"},
+    {file = "geventhttpclient-1.5.5-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd59e9054aea1f36b55b187e87a352ed5bace91326de7323b2975254f51b55fa"},
+    {file = "geventhttpclient-1.5.5-pp37-pypy37_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5f8f077d4165f44eafc6d9a0ec6c0fbf01905d9b4d5132918f6034d53edf7781"},
+    {file = "geventhttpclient-1.5.5-pp37-pypy37_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:61ee04540346ee99afeac9d905cf47398f1b1a368c54dd5415ebb1dc86c796e0"},
+    {file = "geventhttpclient-1.5.5-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:b01b1092e8ee989f5d21bb84da5ee61c179e795ce024c897676f87e438847ce7"},
+    {file = "geventhttpclient-1.5.5.tar.gz", hash = "sha256:1f4f973fb9f6afe4ceec139d5d5d8199b5733371a6d2ecc065e257c81020539b"},
 ]
 greenlet = [
     {file = "greenlet-1.1.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:58df5c2a0e293bf665a51f8a100d3e9956febfbf1d9aaf8c0677cf70218910c6"},
@@ -619,6 +606,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -631,6 +619,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -639,6 +628,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -647,6 +637,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -655,6 +646,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
@@ -705,23 +697,20 @@ grpcio = [
     {file = "grpcio-1.41.0-cp39-cp39-win_amd64.whl", hash = "sha256:4537bb9e35af62c5189493792a8c34d127275a6d175c8ad48b6314cacba4021e"},
     {file = "grpcio-1.41.0.tar.gz", hash = "sha256:15c04d695833c739dbb25c88eaf6abd9a461ec0dbd32f44bc8769335a495cf5a"},
 ]
-idna = [
-    {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
-    {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
-]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 networkx = [
-    {file = "networkx-2.8.4-py3-none-any.whl", hash = "sha256:6933b9b3174a0bdf03c911bb4a1ee43a86ce3edeb813e37e1d4c553b3f4a2c4f"},
-    {file = "networkx-2.8.4.tar.gz", hash = "sha256:5e53f027c0d567cf1f884dbb283224df525644e43afd1145d64c9d88a3584762"},
+    {file = "networkx-2.8.5-py3-none-any.whl", hash = "sha256:a762f4b385692d9c3a6f2912d058d76d29a827deaedf9e63ed14d397b8030687"},
+    {file = "networkx-2.8.5.tar.gz", hash = "sha256:15a7b81a360791c458c55a417418ea136c13378cfdc06a2dcdc12bd2f9cf09c1"},
 ]
 numpy = [
     {file = "numpy-1.22.3-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:92bfa69cfbdf7dfc3040978ad09a48091143cffb778ec3b03fa170c494118d75"},
     {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
     {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
@@ -795,51 +784,47 @@ pytest-depends = [
     {file = "pytest_depends-1.0.1-py3-none-any.whl", hash = "sha256:a1df072bcc93d77aca3f0946903f5fed8af2d9b0056db1dfc9ed5ac164ab0642"},
 ]
 python-rapidjson = [
-    {file = "python-rapidjson-1.6.tar.gz", hash = "sha256:189cf1a96bf9fcd86d00360f15ad76a83ce0889b8ae8d1cb0fdb2b2995e5a1c8"},
-    {file = "python_rapidjson-1.6-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1a551fe1d4fc81981049f5ad75d03cbe2baf0f17510c1c1f8a33f64da711a2b6"},
-    {file = "python_rapidjson-1.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa6a6c9db2d6a7fab9d139a9efc01ac5dd5b8c10741866bae6562b5319f46f45"},
-    {file = "python_rapidjson-1.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a83f46897d21b4151c8414292a8668ccc36b01bbd6e2066cccde211546ee368"},
-    {file = "python_rapidjson-1.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52e335592286c03dc74dafcc265005504dcd0de45bd0125e493f24e4294dbcef"},
-    {file = "python_rapidjson-1.6-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:1f9346ee1bc29d6c66591198f70049f4ee3b16abe4f237445cf535c0fc86b55c"},
-    {file = "python_rapidjson-1.6-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e4721c7292e3d942b032960f69ef8e4449cb3bfe4a59864f4e63a7c617a4cb70"},
-    {file = "python_rapidjson-1.6-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5a84f953bd0b3ecd12ab20184087ae9c7ddddc26ea12c490c7ae567658d1cddf"},
-    {file = "python_rapidjson-1.6-cp310-cp310-win32.whl", hash = "sha256:a60ae8e2b25ef1e785fed8c1d0c707b2704187449bfcc0d145200630b2215900"},
-    {file = "python_rapidjson-1.6-cp310-cp310-win_amd64.whl", hash = "sha256:8c3799a507c4cfd6f40da012c71e6df8448b943c0c7dae0373d83497ef6bfa74"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f436ca06f22cb5e4425b4f4cddd129781b97c6a83d634233b9840a7bee789f33"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:81b721dd8de89e9ccbacf353a7ce583a7ee0e29028cdab3d4794218fbdc5a627"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82d653300a22f4c875fcba6b307ec4918a7532f765ab2ad848c4a6b97df22f0f"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:368f1bc940afa2bedbe7a6667134aa1e309ae24a463b9a7411cd8be740d85ee0"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:ee6ad88cf69db85869afd31bd6595043b7cde8a914336fc2ff5cedd3015ab501"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:e16dff84f66fb84f55f0bac5996bfab48c9b44ac2d6365efbe9c32623d3eb529"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:85d8eaf8e13c3b659b01a76816bb32b8cb89c20a5985abc1d4b0f7fb250df4c8"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-win32.whl", hash = "sha256:2a37cb963ac0a9f446b74f64705e8d1ea258d71e568c67d479a918796e6858c4"},
-    {file = "python_rapidjson-1.6-cp37-cp37m-win_amd64.whl", hash = "sha256:6e31d7ebf07209cfa352ba7e2a3f741513aee49df39bf91370765f8ece9a0ccd"},
-    {file = "python_rapidjson-1.6-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3152efbe726e2a19036f5a1f9adb03b9bc3e63684215e41400f6a31b12d8ed5c"},
-    {file = "python_rapidjson-1.6-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9a31c0c54ef696a998308f9c56157ec4c03d44757d0d54fab1da11558eb074ce"},
-    {file = "python_rapidjson-1.6-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ca2731c91961b6a592f4cb1c03a0092112cb8d80564cb5a1862dc535adc9ef8"},
-    {file = "python_rapidjson-1.6-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9f565e9c82810a0176c0205e99bf8335e554868f6d8fbc0d361475113d10d107"},
-    {file = "python_rapidjson-1.6-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:1ec31fcd020a2b7a665459476a49961dccaa274e28477c79d92ff9d3463f2f79"},
-    {file = "python_rapidjson-1.6-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:3d262dccb677ca421b295495fa752ac8629da71f40bfbb12076dbbfeaf2b2557"},
-    {file = "python_rapidjson-1.6-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cf0a6ab981c30fae3a74e58a83054f7c10131ac95c9c8f0aa91ba1fb0e653d9"},
-    {file = "python_rapidjson-1.6-cp38-cp38-win32.whl", hash = "sha256:613f39b6f8400e12f61407d0bee1b4a792cd4662a05df7a860fdc6bb943041fd"},
-    {file = "python_rapidjson-1.6-cp38-cp38-win_amd64.whl", hash = "sha256:d7db46676169e0f7aa30bf4ad8ae220bac44565618ba9ba045f1c494102e4d7d"},
-    {file = "python_rapidjson-1.6-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a99f29654b863a37a9f113a4272ea99ce89645a1ae37567f2636c0abec16eb53"},
-    {file = "python_rapidjson-1.6-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd62b7740f403f730e7ad2f588f1a59ccc58af57816e785ec61a62e508982553"},
-    {file = "python_rapidjson-1.6-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b590d367d8944cd0d9a70740e01c18935084da5910c5ec3d34ae5d1ddca9ebb"},
-    {file = "python_rapidjson-1.6-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:64bde481afeec31c75795a59606b5d655748014dba9a83fdeffee57d8b32c1c6"},
-    {file = "python_rapidjson-1.6-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8357de9726a5e8542b1fb0228a8541356d6cdc770338d12cda15d2791c379b85"},
-    {file = "python_rapidjson-1.6-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:2797507b58d83c9b77aa4ce79e958706563faa9ef30d112d7b6b1578000bf345"},
-    {file = "python_rapidjson-1.6-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f0f852c66e57c45ef11dda4329407d4db5095935f26d2a481ff0f509a026b203"},
-    {file = "python_rapidjson-1.6-cp39-cp39-win32.whl", hash = "sha256:e36c446d10391833d0627afbff891e90ffb34bbc470dc158695e4ac2aa0d2496"},
-    {file = "python_rapidjson-1.6-cp39-cp39-win_amd64.whl", hash = "sha256:9c8dc20dd493ea8196cf577fe8881b10e741e00b5ba62190fba31525b4deb79c"},
-]
-requests = [
-    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
-    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
+    {file = "python-rapidjson-1.8.tar.gz", hash = "sha256:170c2ff97d01735f67afd0e1cb0aaa690cb69ae6016e020c6afd5e0ab9b39899"},
+    {file = "python_rapidjson-1.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e7973d1fa329c5aa201530e4871e9b1b96acf029f94b185c9880c55603f1dc29"},
+    {file = "python_rapidjson-1.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3dc6df9ef1502907dcc6f29d7263b864d8cca8decb75c41d8d2c93d163e95e7"},
+    {file = "python_rapidjson-1.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db3fd140d3936a581a59d3d28d29709eb4abf8f24c9eedd443d0a93e3be60fd1"},
+    {file = "python_rapidjson-1.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b33a6971188571a6bb1657a142dad1e5a4768649fe7b9bb15b780c4ab85ff1ef"},
+    {file = "python_rapidjson-1.8-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d99d8de639b6a726a2b85d38660c85690af8feb433521d9e2921a76d50cecb53"},
+    {file = "python_rapidjson-1.8-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:85be364896fd2d50f2a7fd3e7fe6fa2ec11ca48c102c6928dc90acc6974fec44"},
+    {file = "python_rapidjson-1.8-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:760c50fc95b12c3e61ef4615a6f32f5b52a99cf7caf8ee604abe95ec70c1dba9"},
+    {file = "python_rapidjson-1.8-cp310-cp310-win32.whl", hash = "sha256:10019c7830017f88aae2a8d5a2a0b8950f39153d61b497151d6fdb4ab4147808"},
+    {file = "python_rapidjson-1.8-cp310-cp310-win_amd64.whl", hash = "sha256:63d01d6cc3bc12852c95b4d8eb87371d6662b49675da6bab397200c2bfead125"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a94baccef7e4525748e3a3b982d0e7f7119f33d7f77e7b990a136c0192db718f"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec117d760aeb3359f68d0fdf4b994647d9bbf0116db80599d0581d199bc03fe5"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9c1ebd4ae2a5c5afc7f827de46f68f3cc56c69400631ed0f081d26835a34211"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bc92907b31631892707b1ab68b332657e1e225fd6c61610ca22ac85e19c88508"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:6c160e238b23a439b86f2e989a1dc69c8afef4754203f9b8f2d98b881029d51a"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b88de8e0ab4660602087792a8edea2491a82fd61880607072367536543f832be"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:f7ca06fe48ac8b2efda6ddf28fcae3e719757143beb2db87499c1327d0d95692"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-win32.whl", hash = "sha256:c0520efab1918ee37f3ebd51d1dcf34fc94d2b597ca6fcdc07b586474ecbc68f"},
+    {file = "python_rapidjson-1.8-cp37-cp37m-win_amd64.whl", hash = "sha256:c3f9c713c2f92406eac24aaa03cdee60d6a7a46ae357cdf9564894db5a588636"},
+    {file = "python_rapidjson-1.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:01eef80dd5c971b7fe8689afea703255734b7fbb655af0b209f64300d50f9286"},
+    {file = "python_rapidjson-1.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:121dc1d9cae745d379b274f77b5369d0ab420cddedbf5b21613410b25d289985"},
+    {file = "python_rapidjson-1.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4807ea0937b6035b941761b31f046612fc1ace9ff0f53bb1dfc40d2ab4fedb6e"},
+    {file = "python_rapidjson-1.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a1d24eacfc174184fc6ed685b0a3a2162ef0d5b572e949df5b9cd3dc34e40f98"},
+    {file = "python_rapidjson-1.8-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:bc4eeb3281403f147a2c0cf6d60b2d55eab26d4f657b51808802b3c1896d25e0"},
+    {file = "python_rapidjson-1.8-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:715783de6aa406fb3cbf80d5ba06d33dee9b08263416f323ae04cd5c3da8868f"},
+    {file = "python_rapidjson-1.8-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:c6c5157dae7434f2a65250a7dafa1a7dfec71e6971a9f1c8d7ee876f23d14a11"},
+    {file = "python_rapidjson-1.8-cp38-cp38-win32.whl", hash = "sha256:dc1c8c4f01c99b5040048ef70c9e5daeb0acaa972865c35e2920c3ef21e18b0b"},
+    {file = "python_rapidjson-1.8-cp38-cp38-win_amd64.whl", hash = "sha256:e05f78abcf0b52fc0a1a3215d885d52a06076269db0f875ed362660d77d3f91f"},
+    {file = "python_rapidjson-1.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:53a33e38258c1b51d1da588a14645c07f1177feee8693969bdd0084aa14e9898"},
+    {file = "python_rapidjson-1.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77eb0e1fe1fd26496674715290b539eb0212f80096b1fe323d56f7e77a9dcf06"},
+    {file = "python_rapidjson-1.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12c46c3fbd6b22646cfad3cbb5efd8195af58274a6d2ec7e0a7ad45dbf6a2e72"},
+    {file = "python_rapidjson-1.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a47617abcc9e2afc7d9a51a525ca5a8b1fd5bdc1656c887123023f6b7623ba31"},
+    {file = "python_rapidjson-1.8-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:05e57fd2ebeaf9da033b2d56876c4f85530223653c8e465a1a109f804b27f242"},
+    {file = "python_rapidjson-1.8-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:08343f516285077743bba34b98f473d6a0741dc02144ebe6083d6be702445c66"},
+    {file = "python_rapidjson-1.8-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:6948978d44cd63968804281d9efc012dcd3cd969b91229ff9c24582489efd916"},
+    {file = "python_rapidjson-1.8-cp39-cp39-win32.whl", hash = "sha256:55306736ad01f81f266af02885ebb1fcfef341d04fec9685249b910c6e10ed65"},
+    {file = "python_rapidjson-1.8-cp39-cp39-win_amd64.whl", hash = "sha256:776f0267ebff36b80d6017733fd3b0875ecb66f760fcee35e2b8197537e123e8"},
 ]
 setuptools = [
-    {file = "setuptools-62.6.0-py3-none-any.whl", hash = "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"},
-    {file = "setuptools-62.6.0.tar.gz", hash = "sha256:990a4f7861b31532871ab72331e755b5f14efbe52d336ea7f6118144dd478741"},
+    {file = "setuptools-63.2.0-py3-none-any.whl", hash = "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16"},
+    {file = "setuptools-63.2.0.tar.gz", hash = "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
@@ -854,19 +839,19 @@ toml = [
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tritonclient = [
-    {file = "tritonclient-2.22.4-py3-none-any.whl", hash = "sha256:9876e938f7a7926ffbafbf517ffa7d102e07739decf245c53eb506bc9e9cbffa"},
-    {file = "tritonclient-2.22.4-py3-none-manylinux1_x86_64.whl", hash = "sha256:c592d4665095f7ccaaa27d9ca4aae97025b31302ea940b342c2fbba3663fbdcf"},
-    {file = "tritonclient-2.22.4-py3-none-manylinux2014_aarch64.whl", hash = "sha256:6b22acc9dea5a05240b7f388c69fe1a05ab5fd9cf0204b875ad76e4c3e362c6b"},
+    {file = "tritonclient-2.23.0-py3-none-any.whl", hash = "sha256:1d45a240138dcf5025f94d5bd7ed96861d18c949aa4a2b24e2ca88ed402bb8c3"},
+    {file = "tritonclient-2.23.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:9f87b7861e67514052ba5da7f388a55fd1ff83e1292600d547e14e807802ac31"},
+    {file = "tritonclient-2.23.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a922346b87003f409685beb69e60e70994612bb0dc26ed271a22654d6ebcde0f"},
 ]
 urllib3 = [
-    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
-    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+    {file = "urllib3-1.26.10-py2.py3-none-any.whl", hash = "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec"},
+    {file = "urllib3-1.26.10.tar.gz", hash = "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"},
 ]
-"zope.event" = [
+zope-event = [
     {file = "zope.event-4.5.0-py2.py3-none-any.whl", hash = "sha256:2666401939cdaa5f4e0c08cf7f20c9b21423b95e88f4675b1443973bdb080c42"},
     {file = "zope.event-4.5.0.tar.gz", hash = "sha256:5e76517f5b9b119acf37ca8819781db6c16ea433f7e2062c4afc2b6fbedb1330"},
 ]
-"zope.interface" = [
+zope-interface = [
     {file = "zope.interface-5.4.0-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:7df1e1c05304f26faa49fa752a8c690126cf98b40b91d54e6e9cc3b7d6ffe8b7"},
     {file = "zope.interface-5.4.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c98384b254b37ce50eddd55db8d381a5c53b4c10ee66e1e7fe749824f894021"},
     {file = "zope.interface-5.4.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:08f9636e99a9d5410181ba0729e0408d3d8748026ea938f3b970a0249daa8192"},

--- a/hermes/hermes.stillwater/pyproject.toml
+++ b/hermes/hermes.stillwater/pyproject.toml
@@ -12,7 +12,7 @@ python = ">=3.8,<3.11"
 tritonclient = {extras = ["all"], version = "^2.18"}
 numpy = "<1.22.4"
 tblib = "^1.7"
-requests = "^2.26.0"
+urllib3 = "^1.26"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"

--- a/hermes/hermes.stillwater/tests/monitor_data/ensemble_config.pbtxt
+++ b/hermes/hermes.stillwater/tests/monitor_data/ensemble_config.pbtxt
@@ -34,7 +34,7 @@ ensemble_scheduling {
     }
   }
   step {
-    model_name: "stream_0"
+    model_name: "stream"
     model_version: -1
     input_map {
       key: "stream"

--- a/hermes/hermes.stillwater/tests/monitor_data/t0.txt
+++ b/hermes/hermes.stillwater/tests/monitor_data/t0.txt
@@ -2,55 +2,46 @@
 # TYPE nv_inference_request_success counter
 nv_inference_request_success{model="ensemble",version="1"} 0.000000
 nv_inference_request_success{model="stream",version="1"} 0.000000
-nv_inference_request_success{model="stream_0",version="1"} 0.000000
 nv_inference_request_success{model="test-model",version="1"} 0.000000
 # HELP nv_inference_request_failure Number of failed inference requests, all batch sizes
 # TYPE nv_inference_request_failure counter
 nv_inference_request_failure{model="ensemble",version="1"} 0.000000
 nv_inference_request_failure{model="stream",version="1"} 0.000000
-nv_inference_request_failure{model="stream_0",version="1"} 0.000000
 nv_inference_request_failure{model="test-model",version="1"} 0.000000
 # HELP nv_inference_count Number of inferences performed (does not include cached requests)
 # TYPE nv_inference_count counter
 nv_inference_count{model="ensemble",version="1"} 0.000000
 nv_inference_count{model="stream",version="1"} 0.000000
-nv_inference_count{model="stream_0",version="1"} 0.000000
 nv_inference_count{model="test-model",version="1"} 0.000000
 # HELP nv_inference_exec_count Number of model executions performed (does not include cached requests)
 # TYPE nv_inference_exec_count counter
 nv_inference_exec_count{model="ensemble",version="1"} 0.000000
 nv_inference_exec_count{model="stream",version="1"} 0.000000
-nv_inference_exec_count{model="stream_0",version="1"} 0.000000
 nv_inference_exec_count{model="test-model",version="1"} 0.000000
 # HELP nv_inference_request_duration_us Cumulative inference request duration in microseconds (includes cached requests)
 # TYPE nv_inference_request_duration_us counter
 nv_inference_request_duration_us{model="ensemble",version="1"} 0.000000
 nv_inference_request_duration_us{model="stream",version="1"} 0.000000
-nv_inference_request_duration_us{model="stream_0",version="1"} 0.000000
 nv_inference_request_duration_us{model="test-model",version="1"} 0.000000
 # HELP nv_inference_queue_duration_us Cumulative inference queuing duration in microseconds (includes cached requests)
 # TYPE nv_inference_queue_duration_us counter
 nv_inference_queue_duration_us{model="ensemble",version="1"} 0.000000
 nv_inference_queue_duration_us{model="stream",version="1"} 0.000000
-nv_inference_queue_duration_us{model="stream_0",version="1"} 0.000000
 nv_inference_queue_duration_us{model="test-model",version="1"} 0.000000
 # HELP nv_inference_compute_input_duration_us Cumulative compute input duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_input_duration_us counter
 nv_inference_compute_input_duration_us{model="ensemble",version="1"} 0.000000
 nv_inference_compute_input_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_input_duration_us{model="stream_0",version="1"} 0.000000
 nv_inference_compute_input_duration_us{model="test-model",version="1"} 0.000000
 # HELP nv_inference_compute_infer_duration_us Cumulative compute inference duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_infer_duration_us counter
 nv_inference_compute_infer_duration_us{model="ensemble",version="1"} 0.000000
 nv_inference_compute_infer_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_infer_duration_us{model="stream_0",version="1"} 0.000000
 nv_inference_compute_infer_duration_us{model="test-model",version="1"} 0.000000
 # HELP nv_inference_compute_output_duration_us Cumulative inference compute output duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_output_duration_us counter
 nv_inference_compute_output_duration_us{model="ensemble",version="1"} 0.000000
 nv_inference_compute_output_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_output_duration_us{model="stream_0",version="1"} 0.000000
 nv_inference_compute_output_duration_us{model="test-model",version="1"} 0.000000
 # HELP nv_cache_num_entries Number of responses stored in response cache
 # TYPE nv_cache_num_entries gauge
@@ -70,13 +61,11 @@ nv_inference_compute_output_duration_us{model="test-model",version="1"} 0.000000
 # TYPE nv_cache_num_hits_per_model counter
 nv_cache_num_hits_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="stream",version="1"} 0.000000
-nv_cache_num_hits_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_cache_hit_lookup_duration_per_model Total cache hit lookup duration per model, in microseconds
 # TYPE nv_cache_hit_lookup_duration_per_model counter
 nv_cache_hit_lookup_duration_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="stream",version="1"} 0.000000
-nv_cache_hit_lookup_duration_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_gpu_utilization GPU utilization rate [0.0 - 1.0)
 # TYPE nv_gpu_utilization gauge

--- a/hermes/hermes.stillwater/tests/monitor_data/t1.txt
+++ b/hermes/hermes.stillwater/tests/monitor_data/t1.txt
@@ -1,56 +1,47 @@
 # HELP nv_inference_request_success Number of successful inference requests, all batch sizes
 # TYPE nv_inference_request_success counter
 nv_inference_request_success{model="ensemble",version="1"} 10.000000
-nv_inference_request_success{model="stream",version="1"} 0.000000
-nv_inference_request_success{model="stream_0",version="1"} 10.000000
+nv_inference_request_success{model="stream",version="1"} 10.000000
 nv_inference_request_success{model="test-model",version="1"} 10.000000
 # HELP nv_inference_request_failure Number of failed inference requests, all batch sizes
 # TYPE nv_inference_request_failure counter
 nv_inference_request_failure{model="ensemble",version="1"} 2.000000
 nv_inference_request_failure{model="stream",version="1"} 0.000000
-nv_inference_request_failure{model="stream_0",version="1"} 0.000000
 nv_inference_request_failure{model="test-model",version="1"} 0.000000
 # HELP nv_inference_count Number of inferences performed (does not include cached requests)
 # TYPE nv_inference_count counter
 nv_inference_count{model="ensemble",version="1"} 10.000000
-nv_inference_count{model="stream",version="1"} 0.000000
-nv_inference_count{model="stream_0",version="1"} 10.000000
+nv_inference_count{model="stream",version="1"} 10.000000
 nv_inference_count{model="test-model",version="1"} 10.000000
 # HELP nv_inference_exec_count Number of model executions performed (does not include cached requests)
 # TYPE nv_inference_exec_count counter
 nv_inference_exec_count{model="ensemble",version="1"} 10.000000
-nv_inference_exec_count{model="stream",version="1"} 0.000000
-nv_inference_exec_count{model="stream_0",version="1"} 10.000000
+nv_inference_exec_count{model="stream",version="1"} 10.000000
 nv_inference_exec_count{model="test-model",version="1"} 10.000000
 # HELP nv_inference_request_duration_us Cumulative inference request duration in microseconds (includes cached requests)
 # TYPE nv_inference_request_duration_us counter
 nv_inference_request_duration_us{model="ensemble",version="1"} 82781.000000
-nv_inference_request_duration_us{model="stream",version="1"} 0.000000
-nv_inference_request_duration_us{model="stream_0",version="1"} 75590.000000
+nv_inference_request_duration_us{model="stream",version="1"} 75590.000000
 nv_inference_request_duration_us{model="test-model",version="1"} 7038.000000
 # HELP nv_inference_queue_duration_us Cumulative inference queuing duration in microseconds (includes cached requests)
 # TYPE nv_inference_queue_duration_us counter
 nv_inference_queue_duration_us{model="ensemble",version="1"} 2.000000
-nv_inference_queue_duration_us{model="stream",version="1"} 0.000000
-nv_inference_queue_duration_us{model="stream_0",version="1"} 1362.000000
+nv_inference_queue_duration_us{model="stream",version="1"} 1362.000000
 nv_inference_queue_duration_us{model="test-model",version="1"} 492.000000
 # HELP nv_inference_compute_input_duration_us Cumulative compute input duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_input_duration_us counter
 nv_inference_compute_input_duration_us{model="ensemble",version="1"} 4628.000000
-nv_inference_compute_input_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_input_duration_us{model="stream_0",version="1"} 293.000000
+nv_inference_compute_input_duration_us{model="stream",version="1"} 293.000000
 nv_inference_compute_input_duration_us{model="test-model",version="1"} 4330.000000
 # HELP nv_inference_compute_infer_duration_us Cumulative compute inference duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_infer_duration_us counter
 nv_inference_compute_infer_duration_us{model="ensemble",version="1"} 74332.000000
-nv_inference_compute_infer_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_infer_duration_us{model="stream_0",version="1"} 73600.000000
+nv_inference_compute_infer_duration_us{model="stream",version="1"} 73600.000000
 nv_inference_compute_infer_duration_us{model="test-model",version="1"} 728.000000
 # HELP nv_inference_compute_output_duration_us Cumulative inference compute output duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_output_duration_us counter
 nv_inference_compute_output_duration_us{model="ensemble",version="1"} 423.000000
-nv_inference_compute_output_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_output_duration_us{model="stream_0",version="1"} 113.000000
+nv_inference_compute_output_duration_us{model="stream",version="1"} 113.000000
 nv_inference_compute_output_duration_us{model="test-model",version="1"} 308.000000
 # HELP nv_cache_num_entries Number of responses stored in response cache
 # TYPE nv_cache_num_entries gauge
@@ -70,13 +61,11 @@ nv_inference_compute_output_duration_us{model="test-model",version="1"} 308.0000
 # TYPE nv_cache_num_hits_per_model counter
 nv_cache_num_hits_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="stream",version="1"} 0.000000
-nv_cache_num_hits_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_cache_hit_lookup_duration_per_model Total cache hit lookup duration per model, in microseconds
 # TYPE nv_cache_hit_lookup_duration_per_model counter
 nv_cache_hit_lookup_duration_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="stream",version="1"} 0.000000
-nv_cache_hit_lookup_duration_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_gpu_utilization GPU utilization rate [0.0 - 1.0)
 # TYPE nv_gpu_utilization gauge

--- a/hermes/hermes.stillwater/tests/monitor_data/t2.txt
+++ b/hermes/hermes.stillwater/tests/monitor_data/t2.txt
@@ -1,56 +1,47 @@
 # HELP nv_inference_request_success Number of successful inference requests, all batch sizes
 # TYPE nv_inference_request_success counter
 nv_inference_request_success{model="ensemble",version="1"} 10.000000
-nv_inference_request_success{model="stream",version="1"} 0.000000
-nv_inference_request_success{model="stream_0",version="1"} 10.000000
+nv_inference_request_success{model="stream",version="1"} 10.000000
 nv_inference_request_success{model="test-model",version="1"} 15.000000
 # HELP nv_inference_request_failure Number of failed inference requests, all batch sizes
 # TYPE nv_inference_request_failure counter
 nv_inference_request_failure{model="ensemble",version="1"} 2.000000
 nv_inference_request_failure{model="stream",version="1"} 0.000000
-nv_inference_request_failure{model="stream_0",version="1"} 0.000000
 nv_inference_request_failure{model="test-model",version="1"} 0.000000
 # HELP nv_inference_count Number of inferences performed (does not include cached requests)
 # TYPE nv_inference_count counter
 nv_inference_count{model="ensemble",version="1"} 10.000000
-nv_inference_count{model="stream",version="1"} 0.000000
-nv_inference_count{model="stream_0",version="1"} 10.000000
+nv_inference_count{model="stream",version="1"} 10.000000
 nv_inference_count{model="test-model",version="1"} 15.000000
 # HELP nv_inference_exec_count Number of model executions performed (does not include cached requests)
 # TYPE nv_inference_exec_count counter
 nv_inference_exec_count{model="ensemble",version="1"} 10.000000
-nv_inference_exec_count{model="stream",version="1"} 0.000000
-nv_inference_exec_count{model="stream_0",version="1"} 10.000000
+nv_inference_exec_count{model="stream",version="1"} 10.000000
 nv_inference_exec_count{model="test-model",version="1"} 15.000000
 # HELP nv_inference_request_duration_us Cumulative inference request duration in microseconds (includes cached requests)
 # TYPE nv_inference_request_duration_us counter
 nv_inference_request_duration_us{model="ensemble",version="1"} 82781.000000
-nv_inference_request_duration_us{model="stream",version="1"} 0.000000
-nv_inference_request_duration_us{model="stream_0",version="1"} 75590.000000
+nv_inference_request_duration_us{model="stream",version="1"} 75590.000000
 nv_inference_request_duration_us{model="test-model",version="1"} 8554.000000
 # HELP nv_inference_queue_duration_us Cumulative inference queuing duration in microseconds (includes cached requests)
 # TYPE nv_inference_queue_duration_us counter
 nv_inference_queue_duration_us{model="ensemble",version="1"} 2.000000
-nv_inference_queue_duration_us{model="stream",version="1"} 0.000000
-nv_inference_queue_duration_us{model="stream_0",version="1"} 1362.000000
+nv_inference_queue_duration_us{model="stream",version="1"} 1362.000000
 nv_inference_queue_duration_us{model="test-model",version="1"} 810.000000
 # HELP nv_inference_compute_input_duration_us Cumulative compute input duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_input_duration_us counter
 nv_inference_compute_input_duration_us{model="ensemble",version="1"} 4628.000000
-nv_inference_compute_input_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_input_duration_us{model="stream_0",version="1"} 293.000000
+nv_inference_compute_input_duration_us{model="stream",version="1"} 293.000000
 nv_inference_compute_input_duration_us{model="test-model",version="1"} 4632.000000
 # HELP nv_inference_compute_infer_duration_us Cumulative compute inference duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_infer_duration_us counter
 nv_inference_compute_infer_duration_us{model="ensemble",version="1"} 74332.000000
-nv_inference_compute_infer_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_infer_duration_us{model="stream_0",version="1"} 73600.000000
+nv_inference_compute_infer_duration_us{model="stream",version="1"} 73600.000000
 nv_inference_compute_infer_duration_us{model="test-model",version="1"} 1061.000000
 # HELP nv_inference_compute_output_duration_us Cumulative inference compute output duration in microseconds (does not include cached requests)
 # TYPE nv_inference_compute_output_duration_us counter
 nv_inference_compute_output_duration_us{model="ensemble",version="1"} 423.000000
-nv_inference_compute_output_duration_us{model="stream",version="1"} 0.000000
-nv_inference_compute_output_duration_us{model="stream_0",version="1"} 113.000000
+nv_inference_compute_output_duration_us{model="stream",version="1"} 113.000000
 nv_inference_compute_output_duration_us{model="test-model",version="1"} 514.000000
 # HELP nv_cache_num_entries Number of responses stored in response cache
 # TYPE nv_cache_num_entries gauge
@@ -70,13 +61,11 @@ nv_inference_compute_output_duration_us{model="test-model",version="1"} 514.0000
 # TYPE nv_cache_num_hits_per_model counter
 nv_cache_num_hits_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="stream",version="1"} 0.000000
-nv_cache_num_hits_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_num_hits_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_cache_hit_lookup_duration_per_model Total cache hit lookup duration per model, in microseconds
 # TYPE nv_cache_hit_lookup_duration_per_model counter
 nv_cache_hit_lookup_duration_per_model{model="ensemble",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="stream",version="1"} 0.000000
-nv_cache_hit_lookup_duration_per_model{model="stream_0",version="1"} 0.000000
 nv_cache_hit_lookup_duration_per_model{model="test-model",version="1"} 0.000000
 # HELP nv_gpu_utilization GPU utilization rate [0.0 - 1.0)
 # TYPE nv_gpu_utilization gauge

--- a/hermes/hermes.stillwater/tests/test_monitor.py
+++ b/hermes/hermes.stillwater/tests/test_monitor.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from google.protobuf import text_format
+from tritonclient.grpc.model_config_pb2 import ModelConfig
+
+from hermes.stillwater.monitor import ServerMonitor, _processes
+
+data_path = Path(__file__).resolve().parent / "monitor_data"
+metadata_mock = MagicMock()
+metadata_mock.versions = [1]
+
+
+def get_config_patch(obj, model_name):
+    config_path = data_path / f"{model_name}_config.pbtxt"
+    config = ModelConfig()
+    with open(config_path, "r") as f:
+        text_format.Merge(f.read(), config)
+
+    mock = MagicMock()
+    mock.config = config
+    return mock
+
+
+def get_response(i: int):
+    response_path = data_path / f"t{i}.txt"
+    with open(response_path, "r") as f:
+        content = f.read()
+
+    response = MagicMock()
+    response.data.decode = MagicMock(return_value=content)
+    return response
+
+
+@patch(
+    "tritonclient.grpc.InferenceServerClient.get_model_config",
+    new=get_config_patch,
+)
+def test_server_monitor_on_standalone_model():
+    monitor = ServerMonitor(
+        "test-model",
+        ips="localhost",
+        filename="test.csv",
+        model_version=1,  # TODO: test -1 behavior
+        name="monitor",
+    )
+
+    http = MagicMock()
+    http.request = MagicMock(return_value=get_response(0))
+    tracker = {"test-model": {}}
+
+    result = monitor.parse_for_ip("localhost", http, tracker)
+    assert len(result) == 0
+    assert len(tracker["test-model"]) == (len(_processes) + 1)
+    for process in _processes + ["count"]:
+        assert tracker["test-model"][process] == 0
+
+    http.request = MagicMock(return_value=get_response(1))
+    result = monitor.parse_for_ip("localhost", http, tracker)
+    assert len(result) == 1
+
+    result = result[0].split(",")
+    assert len(result) == 9
+    assert result[1] == "localhost"
+    assert result[2] == "test-model"
+    assert int(result[3]) == tracker["test-model"]["count"] == 10
+    assert int(result[-1]) == tracker["test-model"]["request"] == 7038
+
+
+@patch(
+    "tritonclient.grpc.InferenceServerClient.get_model_config",
+    new=get_config_patch,
+)
+@patch(
+    "tritonclient.grpc.InferenceServerClient.get_model_metadata",
+    return_value=metadata_mock,
+)
+def test_server_monitor_on_ensemble_model(mock1):
+    monitor = ServerMonitor(
+        "ensemble",
+        ips="localhost",
+        filename="test.csv",
+        model_version=1,  # TODO: test -1 behavior
+        name="monitor",
+    )
+
+    assert set(monitor.models) == set(["stream", "test-model"])
+    assert monitor.versions == [1, 1]
+
+    http = MagicMock()
+    http.request = MagicMock(return_value=get_response(0))
+    tracker = {i: {} for i in monitor.models}
+
+    result = monitor.parse_for_ip("localhost", http, tracker)
+    assert len(result) == 0
+    for model in monitor.models:
+        assert len(tracker[model]) == (len(_processes) + 1)
+        for process in _processes + ["count"]:
+            assert tracker[model][process] == 0
+
+    http.request = MagicMock(return_value=get_response(1))
+    result = monitor.parse_for_ip("localhost", http, tracker)
+    assert len(result) == 2
+
+    latencies = {"stream": 75590, "test-model": 7038}
+    for row, model, latency in zip(result, monitor.models, latencies):
+        row = row.split(",")
+        assert len(row) == 9
+        assert row[1] == "localhost"
+        assert row[2] == model
+        assert int(row[3]) == tracker[model]["count"] == 10
+        assert int(row[-1]) == tracker[model]["request"] == latencies[model]
+
+    http.request = MagicMock(return_value=get_response(2))
+    result = monitor.parse_for_ip("localhost", http, tracker)
+    assert len(result) == 1
+
+    row = result[0].split(",")
+    assert row[2] == "test-model"
+    assert int(row[3]) == 5
+    assert tracker["test-model"]["count"] == 15
+    assert int(row[-1]) == 1516
+    assert tracker["test-model"]["request"] == 8554
+
+    assert tracker["stream"]["count"] == 10
+    assert tracker["stream"]["request"] == 75590


### PR DESCRIPTION
Triton has abandoned per-GPU metrics for model inference stats, so overhauling the monitor class for this simplification and adopting some neater notations.

- [ ] Get model configs and example metrics outputs for tests
- [ ] Write unit tests
- [ ] File issue for implementing non-process version of this in `hermes.aeriel`