### PR TITLE
Fixes found during low-latency F2F week

### DIFF
--- a/hermes/hermes.aeriel/poetry.lock
+++ b/hermes/hermes.aeriel/poetry.lock
@@ -324,7 +324,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "spython"
-version = "0.1.18"
+version = "0.2.13"
 description = "Command line python tool for working with singularity."
 category = "main"
 optional = true
@@ -412,7 +412,7 @@ serve = ["spython"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "d371054de3c9ae22c90e5c3d065aeaef6595e3a82b31c26eeac48850d1c03bba"
+content-hash = "2b961f07c494893d5cc014dc3bb7d2dc03ae7ba674fb9dba211d26e3a05d32f6"
 
 [metadata.files]
 aiohttp = [
@@ -1117,7 +1117,7 @@ six = [
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 spython = [
-    {file = "spython-0.1.18.tar.gz", hash = "sha256:1a58735f1d119976ffef63619d0e0b626d43151f84a5d63cb3d67a34b14991a1"},
+    {file = "spython-0.2.13.tar.gz", hash = "sha256:d50632275d4cd60839124f4d5b0a548b4cdedae5e71de0da80b768f8e37e9a6f"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/hermes/hermes.aeriel/pyproject.toml
+++ b/hermes/hermes.aeriel/pyproject.toml
@@ -13,7 +13,7 @@ python = ">=3.8,<3.11"
 tritonclient = {extras = ["all"], version = "^2.22"}
 
 numpy = {version = "^1.22", optional = true}
-spython = {version = "^0.1", optional = true}
+spython = {version = "^0.2", optional = true}
 
 [tool.poetry.extras]
 client = ["numpy"]

--- a/hermes/hermes.quiver/hermes/quiver/io/file_system.py
+++ b/hermes/hermes.quiver/hermes/quiver/io/file_system.py
@@ -1,6 +1,7 @@
 import abc
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List, Optional
+from pathlib import Path
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from google.protobuf import text_format
 from tritonclient.grpc.model_config_pb2 import ModelConfig
@@ -11,7 +12,7 @@ if TYPE_CHECKING:
 
 @dataclass
 class FileSystem(metaclass=abc.ABCMeta):
-    root: str
+    root: Union[Path, str]
 
     @abc.abstractmethod
     def soft_makedirs(self, path: str) -> bool:

--- a/hermes/hermes.quiver/hermes/quiver/io/gcs.py
+++ b/hermes/hermes.quiver/hermes/quiver/io/gcs.py
@@ -204,3 +204,6 @@ class GCSFileSystem(FileSystem):
             )
 
         blob.upload_from_string(obj, content_type=content_type)
+
+    def __str__(self):
+        return f"gs://{self.bucket}/{self.root}"

--- a/hermes/hermes.quiver/hermes/quiver/io/local.py
+++ b/hermes/hermes.quiver/hermes/quiver/io/local.py
@@ -2,6 +2,7 @@ import glob
 import os
 import shutil
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, List, Optional
 
 from hermes.quiver.io.exceptions import NoFilesFoundError
@@ -14,6 +15,12 @@ if TYPE_CHECKING:
 @dataclass
 class LocalFileSystem(FileSystem):
     def __post_init__(self):
+        # TODO: switch to preferring Path as root
+        # and using pathlib apis instead of os.
+        if not isinstance(self.root, Path):
+            self.root = Path(self.root)
+        self.root = str(self.root.resolve())
+
         self.soft_makedirs("")
 
     def soft_makedirs(self, path: str):
@@ -90,3 +97,6 @@ class LocalFileSystem(FileSystem):
 
         with open(path, mode) as f:
             f.write(obj)
+
+    def __str__(self):
+        return self.root

--- a/hermes/hermes.quiver/hermes/quiver/model.py
+++ b/hermes/hermes.quiver/hermes/quiver/model.py
@@ -75,6 +75,12 @@ class Model:
 
     def __post_init__(self):
         self.fs.soft_makedirs(self.name)
+
+        # TODO: should we write config on initialization
+        # so that repos can be reinitialized even if a
+        # model hasn't exported a version yet? Or do we
+        # want to enforce that written configs be useable
+        # by Triton
         self.config = ModelConfig(self)
 
     @property

--- a/hermes/hermes.quiver/hermes/quiver/model_config.py
+++ b/hermes/hermes.quiver/hermes/quiver/model_config.py
@@ -26,7 +26,7 @@ def _add_exposed_tensor(f):
         obj: "ModelConfig",
         name: str,
         shape: "SHAPE_TYPE",
-        dtype: str = Literal["float32", "int64"],
+        dtype: Literal["float32", "int64"] = "float32",
         **kwargs,  # including kwargs for reshaping later or something
     ) -> output_type:
         """Add an {exposed} tensor to the config

--- a/hermes/hermes.quiver/hermes/quiver/model_repository.py
+++ b/hermes/hermes.quiver/hermes/quiver/model_repository.py
@@ -1,20 +1,62 @@
 import re
-from typing import Union
+from pathlib import Path
+from typing import Any, Union
 
 from hermes.quiver import Model, Platform, io
 
 
 class ModelRepository:
-    def __init__(self, root: str, **kwargs) -> None:
+    """Object representing a directory structured as a Triton model repository
+
+    Triton model repositories are local or cloud-based
+    directories that follow a very strict structure. This
+    utility class aids in implementing and maintaining
+    such a structure and keeping track of the models contained
+    in this repository. Currently local directories and
+    Google Cloud Storage buckets are supported locations for
+    model repositories.
+
+    If a repository already exists at the specified location,
+    an attempt will be made to add any existing models to
+    the in-memory model cache. If no config file exists for
+    these models, their corresponding Platform cannot be
+    inferred and so a `ValueError` will be raised.
+
+    Args:
+        root:
+            The path to the root level of the model repository.
+            To specify a Google Cloud Storage bucket, pass a
+            string beginning with `"gs://"`.
+        clean:
+            Whether to remove all existing models from the
+            repository. This is useful if previous attempts
+            to export models resulted in errors and as a result
+            they don't have a valid config.
+        kwargs:
+            Any keyword arguments to pass to the initialization
+            of the underlying filesystem object managing the repository.
+    """
+
+    def __init__(
+        self, root: Union[str, Path], clean: bool = False, **kwargs: Any
+    ) -> None:
         # initialize the filesystem backend for managing
         # reading/writing/path operations
-        if root.startswith("gs://"):
+        if isinstance(root, str) and root.startswith("gs://"):
             self.fs = io.GCSFileSystem(root.replace("gs://", ""), **kwargs)
         else:
             self.fs = io.LocalFileSystem(root)
 
-        # load in any models that already exist in the repository
-        # initialize a `_models` attribute to wrap with a `models` property
+        if clean:
+            self.fs.remove("*")
+        self.refresh()
+
+    def refresh(self) -> None:
+        """
+        Reload the in-memory model cache using the current
+        state of the repository filesystem.
+        """
+
         self._models = []
         for model in self.fs.list(""):
             # try to read the config for the model, and if it
@@ -28,8 +70,8 @@ class ModelRepository:
                 )
             except FileNotFoundError:
                 raise ValueError(
-                    f"Failed to initialize repo at {root} "
-                    f"due to model with missing config {model}"
+                    "Failed to initialize repo at {} due to "
+                    "model {} with missing config.".format(self.fs, model)
                 )
 
             # make sure the specified platform is legitimate
@@ -42,8 +84,8 @@ class ModelRepository:
             except KeyError:
                 raise ValueError(
                     "Failed to initialize repo at {} due to "
-                    "model {} with unknown platform {}".format(
-                        self.root, model, config.platform
+                    "model {} with unknown platform {}.".format(
+                        self.fs, model, config.platform
                     )
                 )
             self.add(model, platform)
@@ -55,6 +97,31 @@ class ModelRepository:
         return {model.name: model for model in self._models}
 
     def add(self, name: str, platform: Platform, force: bool = False) -> Model:
+        """
+        Add a new model entry to this repository. If the model
+        already exists, a `ValueError` will be raised unless
+        `force` is `True`, in which case a new model will be
+        created with an incremented integer appended to the
+        model name.
+
+        Args:
+            name:
+                Name of the model. Will also be the name of the
+                corresponding directory in the model repository.
+            platform:
+                Desired inference platform Triton will use to
+                execute the model at inference time.
+            force:
+                Whether to force the addition of this model, even
+                if a model of the same name already exists in the
+                repository. In this case, the model name will be
+                appended by `_<idx>`, where `idx` represents the
+                lowest non-negative integer possible in order to
+                create a unique name in the repository's index.
+        Returns:
+            The created `Model` object
+        """
+
         if name in self.models and not force:
             raise ValueError("Model {} already exists".format(name))
         elif name in self.models:

--- a/hermes/hermes.quiver/tests/conftest.py
+++ b/hermes/hermes.quiver/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from hermes.quiver import ModelRepository
 from hermes.quiver.io import GCSFileSystem, LocalFileSystem
+from hermes.quiver.io.exceptions import NoFilesFoundError
 
 
 @pytest.fixture(
@@ -22,7 +23,11 @@ def fs(request):
 def temp_fs(fs):
     filesystem = fs("hermes-quiver-test")
     yield filesystem
-    filesystem.delete()
+
+    try:
+        filesystem.delete()
+    except NoFilesFoundError:
+        pass
 
 
 @pytest.fixture(scope="module")
@@ -56,7 +61,6 @@ def keras_model(dim, tf):
     import tensorflow as tf
 
     scope = "".join(random.choices("abcdefghijk", k=10))
-
     model = tf.keras.Sequential(
         [
             tf.keras.layers.Dense(

--- a/hermes/hermes.stillwater/hermes/stillwater/monitor.py
+++ b/hermes/hermes.stillwater/hermes/stillwater/monitor.py
@@ -281,6 +281,7 @@ class ServerMonitor(PipelineProcess):
                 if lines:
                     with lock:
                         f.write("\n" + "\n".join(lines))
+                        f.flush()
                 time.sleep(1 / self.max_request_rate)
         except Exception as e:
             self.logger.error(f"Encountered error in parsing ip {ip}:\n {e}")


### PR DESCRIPTION
- Updating `spython` dependency from `hermes.aeriel[serve]` to avoid issues with deprecated `instance.start` syntax. Broader investigation into future compatibility with apptainer is needed
- Flushing file writes in `hermes.stillwater.ServerMonitor` to make data available during inference
- Adding a `clean` kwarg to `ModelRepository` which will clear it before initialization
- Adding tests for `ModelRepository`