### PR TITLE
Faster averager

### DIFF
--- a/hermes/hermes.quiver/hermes/quiver/streaming/streaming_output.py
+++ b/hermes/hermes.quiver/hermes/quiver/streaming/streaming_output.py
@@ -9,6 +9,21 @@ if TYPE_CHECKING:
     from hermes.quiver.model import ExposedTensor
 
 
+def window(x: torch.Tensor, num_windows: int, stride: int):
+    if x.ndim == 2:
+        num_channels = len(x)
+        x = x.view(1, num_channels, 1, -1)
+    else:
+        x = x.view(1, 1, 1, -1)
+        num_channels = 1
+
+    x = torch.nn.functional.unfold(
+        x, kernel_size=(1, num_windows), dilation=(1, stride)
+    )
+    x = x.reshape(num_channels, num_windows, -1)
+    return x.transpose(1, 0)
+
+
 class OnlineAverager(torch.nn.Module):
     def __init__(
         self,
@@ -21,14 +36,27 @@ class OnlineAverager(torch.nn.Module):
         self.update_size = update_size
         self.num_updates = num_updates
         self.batch_size = batch_size
-        self.snapshot_size = update_size * num_updates
+        self.num_channels = num_channels
 
-        normalizer = torch.arange(num_updates) + 1
-        normalizer = normalizer.flip(-1)
-        normalizer = torch.repeat_interleave(normalizer, update_size)
+        snapshot_size = (batch_size + num_updates - 1) * update_size
+        if num_channels is None:
+            blank = torch.zeros((batch_size, snapshot_size))
+        else:
+            blank = torch.zeros((batch_size, num_channels, snapshot_size))
+        self.register_buffer("blank", blank)
 
-        self.register_buffer("normalizer", normalizer)
-        self.register_buffer("zero", torch.zeros((1,)))
+        idx = torch.arange(num_updates * update_size)
+        idx = torch.stack([idx + i * update_size for i in range(batch_size)])
+        if num_channels is not None:
+            idx = idx.view(batch_size, 1, -1).repeat(1, num_channels, 1)
+        self.register_buffer("idx", idx)
+
+        weights = torch.scatter(blank, -1, idx, 1).sum(0)
+        weights = window(weights, batch_size, update_size)
+        if num_channels is None:
+            weights = weights[:, 0]
+
+        self.register_buffer("weights", weights)
 
         pad_shape = (update_size * batch_size,)
         if num_channels is not None:
@@ -37,36 +65,33 @@ class OnlineAverager(torch.nn.Module):
         self.register_buffer("pad", pad)
 
     def forward(
-        self,
-        update: torch.Tensor,
-        snapshot: torch.Tensor,
-        update_idx: torch.Tensor,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        for i in range(self.batch_size):
-            if update.ndim > 2:
-                x = update[i, :, -self.snapshot_size :]
-            else:
-                x = update[i, -self.snapshot_size :]
+        self, update: torch.Tensor, snapshot: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        if self.num_channels is None:
+            update = update[:, None]
 
-            weights = self.normalizer.clamp(self.zero, update_idx + i + 1)
-            start = i * self.update_size
-            stop = start + x.shape[-1]
+        keep = self.num_updates * self.update_size
+        x = update[:, :, -keep:] / self.num_updates
 
-            if update.ndim > 2:
-                prev = snapshot[:, start:stop]
-                snapshot[:, start:stop] += (x - prev) / weights
-            else:
-                prev = snapshot[start:stop]
-                snapshot[start:stop] += (x - prev) / weights
+        windowed = window(snapshot, self.batch_size, self.update_size)
+        if self.num_channels is None:
+            windowed = windowed[:, 0]
+            x = x[:, 0]
+        windowed /= self.weights
+        windowed += x
 
-        output_size = self.update_size * self.batch_size
-        snapshot_size = snapshot.shape[-1] - output_size
-        output, snapshot = torch.split(
-            snapshot, [output_size, snapshot_size], dim=-1
-        )
+        padded = torch.scatter(self.blank, -1, self.idx, windowed)
+        snapshot = padded.sum(axis=0)
 
-        snapshot = torch.concat([snapshot, self.pad], axis=-1)
-        return output[None], snapshot, update_idx + self.batch_size
+        if self.num_updates == 1:
+            return snapshot[None], self.pad
+        else:
+            splits = [self.batch_size, self.num_updates - 1]
+            output, snapshot = torch.split(
+                snapshot, [i * self.update_size for i in splits], dim=-1
+            )
+        snapshot = torch.cat([snapshot, self.pad], axis=-1)
+        return output[None], snapshot
 
 
 def make_streaming_output_model(
@@ -127,8 +152,8 @@ def make_streaming_output_model(
         name=name or "aggregator",
         input_name="update",
         input_shape=(batch_size,) + input.shape[1:],
-        state_names=["online_average", "update_index"],
-        state_shapes=[snapshot_shape, (1,)],
+        state_names=["online_average"],
+        state_shapes=[snapshot_shape],
         output_names=["output_stream"],
         streams_per_gpu=streams_per_gpu,
     )

--- a/hermes/hermes.quiver/poetry.lock
+++ b/hermes/hermes.quiver/poetry.lock
@@ -1311,14 +1311,14 @@ testing = ["coverage (>=5.0.3)", "zope-event", "zope-testing"]
 
 [extras]
 gcs = ["google-cloud-storage"]
-tensorflow = ["tensorflow", "libclang"]
+tensorflow = ["tensorflow"]
 tensorrt = ["nvidia-tensorrt"]
-torch = ["torch", "urllib3"]
+torch = ["torch"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.11"
-content-hash = "8875fbb508f1c7d4d605d829a9b3c7f63094fed28853a7518583d772c55666ed"
+content-hash = "80cb181cfaa674a60b070f23f626a74857cfd9d087aa75597291ab1c1a4d87c8"
 
 [metadata.files]
 absl-py = [

--- a/hermes/hermes.quiver/pyproject.toml
+++ b/hermes/hermes.quiver/pyproject.toml
@@ -15,20 +15,9 @@ protobuf = "^3.17"
 requests = "^2.26.0"
 
 # optional dependencies
-# tensorlfow optional dependencies
 tensorflow = {version = "^2.3", optional = true}
-
-# torch optional dependencies
 torch = {version = "^1.7", optional = true}
-# for some reason this is missing in the `requests`
-# install in the torch environment, so add it as
-# an optional dependency just for that extra
-# urllib3 = { version = "^1.26", optional = true }
-
-# gcs filesystem backend optional dependencies
 google-cloud-storage = {version = "^1.38", optional = true }
-
-# tensorrt export platform optional dependencies
 nvidia-tensorrt = { version = "^8.0", optional = true, source = "ngc" }
 
 [tool.poetry.extras]

--- a/hermes/hermes.quiver/pyproject.toml
+++ b/hermes/hermes.quiver/pyproject.toml
@@ -16,19 +16,14 @@ requests = "^2.26.0"
 
 # optional dependencies
 # tensorlfow optional dependencies
-tensorflow = {version = "^2.3", optional = true }
-# explicitly adding a libclang dependency for now
-# due to this transient issue
-# https://pythonissues.com/issues/2674747
-# TODO: check if this has been resolved
-libclang = {version = "<12.0", optional = true}
+tensorflow = {version = "^2.3", optional = true}
 
 # torch optional dependencies
-torch = {version = "^1.7", optional = true }
+torch = {version = "^1.7", optional = true}
 # for some reason this is missing in the `requests`
 # install in the torch environment, so add it as
 # an optional dependency just for that extra
-urllib3 = { version = "^1.26", optional = true }
+# urllib3 = { version = "^1.26", optional = true }
 
 # gcs filesystem backend optional dependencies
 google-cloud-storage = {version = "^1.38", optional = true }
@@ -37,7 +32,7 @@ google-cloud-storage = {version = "^1.38", optional = true }
 nvidia-tensorrt = { version = "^8.0", optional = true, source = "ngc" }
 
 [tool.poetry.extras]
-tensorflow = ["tensorflow", "libclang"]
+tensorflow = ["tensorflow"]
 torch = ["torch", "urllib3"]
 gcs = ["google-cloud-storage"]
 tensorrt = ["nvidia-tensorrt"]

--- a/hermes/hermes.quiver/tests/test_model_repository.py
+++ b/hermes/hermes.quiver/tests/test_model_repository.py
@@ -1,0 +1,67 @@
+import pytest
+
+from hermes.quiver import ModelRepository, Platform
+from hermes.quiver.io import LocalFileSystem
+
+
+def test_model_repository(temp_fs):
+    repo = ModelRepository(str(temp_fs))
+    assert len(repo.models) == 0
+
+    model = repo.add("test-model", platform=Platform.ONNX)
+    assert model.name == "test-model"
+    assert model.platform == Platform.ONNX
+    assert len(model.config.input) == 0
+    assert len(model.config.output) == 0
+    assert len(model.versions) == 0
+
+    # creating the same model without force raises an error
+    with pytest.raises(ValueError):
+        model = repo.add("test-model", platform=Platform.ONNX)
+
+    # make sure index gets appended
+    model = repo.add("test-model", platform=Platform.ONNX, force=True)
+    assert model.name == "test-model_0"
+
+    # remove then re-add the model to make sure it gets
+    # the appropriate name
+    repo.remove("test-model")
+    assert len(repo.models) == 1
+    model = repo.add("test-model", platform=Platform.ONNX)
+    assert model.name == "test-model"
+    assert len(repo.models) == 2
+
+    # now delete a model externally and make sure
+    # that the refresh recreates the correct state
+    temp_fs.remove("test-model_0")
+    assert len(repo.models) == 2
+
+    with pytest.raises(ValueError):
+        # this will fail since test-model hasn't
+        # written a config yet
+        repo.refresh()
+
+    model.config.write()
+    repo.refresh()
+    assert len(repo.models) == 1
+
+    # make sure that recreating the repo initializes
+    # the models correctly
+    repo = ModelRepository(str(temp_fs))
+    assert len(repo.models) == 1
+
+    # now make sure the clean functionality works
+    repo = ModelRepository(str(temp_fs), clean=True)
+    assert len(repo.models) == len(temp_fs.list("")) == 0
+
+    # finally make sure the repo deletion works
+    model = repo.add("test-model", platform=Platform.ONNX)
+    assert len(repo.models) == len(temp_fs.list("")) == 1
+
+    repo.delete()
+    assert len(repo.models) == 0
+
+    # TODO: what's the check for GCSFileSystem
+    if isinstance(temp_fs, LocalFileSystem):
+        with pytest.raises(FileNotFoundError):
+            temp_fs.list("")


### PR DESCRIPTION
Accelerating the online averager by getting rid of for-loop. The tradeoff is that the first `num_updates` predictions will be underestimated by a factor `(i + 1) / num_updates`, where `i` is the index of the prediction. This could probably be fixed by reintroducing an `update_idx` argument, but since I'm primarily interested in optimizing DeepClean at the moment I'm willing to let this slide and note it in the documentation somewhere (or file an issue to do so).