### PR TITLE
Fixing issues with TensorRT re-export of an existing model

### DIFF
--- a/hermes/hermes.quiver/hermes/quiver/exporters/torch_tensorrt.py
+++ b/hermes/hermes.quiver/hermes/quiver/exporters/torch_tensorrt.py
@@ -59,24 +59,10 @@ class TorchTensorRT(TorchOnnx, metaclass=TorchTensorRTMeta):
         def do_conversion(model_binary, config):
             # merge info about inputs and outputs from
             # the existing config into our config
-            # do this in a few steps to be safe:
-            # create a copy of this model's config (which
-            # may or may not have info about inputs/outputs)
-            # TODO: do we just need to merge in inputs/outputs?
-            # can we use this with _check_exposed_tensors?
-            temp_config = deepcopy(self.config._config)
-
-            # merge in the config from the model
-            # we're converting from
-            temp_config.MergeFrom(config)
-
-            # then merge back in our config so that
-            # things like platform, max_batch_size, etc.
-            # are preserved.
-            temp_config.MergeFrom(self.config._config)
-
-            # now set our config to this copy's value
-            self.config._config = temp_config
+            inputs = {i.name: tuple(i.dims) for i in config.input}
+            outputs = {i.name: tuple(i.dims) for i in config.output}
+            self._check_exposed_tensors("input", inputs)
+            self._check_exposed_tensors("output", outputs)
 
             if endpoint is None:
                 # do the conversion locally

--- a/hermes/hermes.quiver/hermes/quiver/model_config.py
+++ b/hermes/hermes.quiver/hermes/quiver/model_config.py
@@ -109,7 +109,15 @@ class ModelConfig:
             config = model.fs.read_config(
                 model.fs.join(model.name, "config.pbtxt")
             )
-
+        except FileNotFoundError:
+            # create a new config if one doesn't
+            # already exist
+            config = model_config.ModelConfig(
+                name=model.name,
+                platform=model.platform.value,
+                **kwargs,
+            )
+        else:
             # ensure that the name in the config
             # matches the name passed from the model
             if config.name != model.name:
@@ -133,15 +141,6 @@ class ModelConfig:
             # their existing value in the config
             kwargs_config = model_config.ModelConfig(**kwargs)
             config.MergeFrom(kwargs_config)
-
-        except FileNotFoundError:
-            # create a new config if one doesn't
-            # already exist
-            config = model_config.ModelConfig(
-                name=model.name,
-                platform=model.platform.value,
-                **kwargs,
-            )
 
         # add it as an attribute
         self._config = config
@@ -253,6 +252,16 @@ class ModelConfig:
 
     def __str__(self):
         return str(self._config)
+
+    def __copy__(self):
+        obj = ModelConfig(self.model)
+        obj._config = self._config.__copy__()
+        return obj
+
+    def __deepcopy__(self, memo=None):
+        obj = ModelConfig(self.model)
+        obj._config = self._config.__deepcopy__(memo)
+        return obj
 
 
 class EnsembleConfig(ModelConfig):


### PR DESCRIPTION
As noted in ML4GW/BBHNet#204, there are issues when trying to export a previously existing TensorRT model from torch stemming from the way we're naively merging configs. This uses the existing `_check_exposed_tensors` method to simplify and fix this.

- [x] Add tests mocking actual export to ensure that configs match