### PR TITLE
Infer parameter info directly from torchscript graph

### DIFF
--- a/hermes/hermes.quiver/hermes/quiver/exporters/torch_onnx.py
+++ b/hermes/hermes.quiver/hermes/quiver/exporters/torch_onnx.py
@@ -13,6 +13,13 @@ except ImportError:
 from hermes.quiver import Platform
 from hermes.quiver.exporters import Exporter
 
+def get_input_names_from_script_module(m: torch.jit.ScriptModule):
+    graph = m.graph
+    input_names = [node.debugName().split(".")[0] for node in graph.inputs()]
+    if "self" in input_names:
+        input_names.remove("self")
+    return OrderedDict({name: name for name in input_names})
+
 
 class TorchOnnxMeta(abc.ABCMeta):
     @property
@@ -55,11 +62,14 @@ class TorchOnnx(Exporter, metaclass=TorchOnnxMeta):
             # generate an input array of random data
             input_tensors[input.name] = self._get_tensor(input.dims)
 
-        # use function signature from module.forward
-        # to figure out in which order to pass input
-        # tensors to the model_fn
-        signature = inspect.signature(model_fn.forward)
-        parameters = OrderedDict(signature.parameters)
+        # parse script module to figure out in which order 
+        # to pass input tensors to the model_fn
+        if isinstance(model_fn, torch.jit.ScriptModule):
+            parameters = get_input_names_from_script_module(model_fn)
+        # otherwise use function signature from module.forward
+        else:
+            signature = inspect.signature(model_fn.forward)
+            parameters = OrderedDict(signature.parameters)
 
         # make sure the number of inputs to
         # the model_fn matches the number of


### PR DESCRIPTION
When converting from torch model to tensorrt, if input is a `TorchScript` model, it is not possible to directly infer model parameters from `forward` method via `inspect` libray.

Instead, infer parameters directly from model graph.
