### PR TITLE
v0.1.0 release branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,18 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: PyPI
+    steps:
+    - uses: actions/checkout@v2
+    - 
+      name: Build and publish to pypi
+      uses: JRubics/poetry-publish@v1.16
+      with:
+        python_version: "3.10.9"
+        pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [tool.poetry]
-name = "hermes"
-version = "0.0.1"
+name = "ml4gw-hermes"
+version = "0.1.0"
 description = "Inference-as-a-Service deployment made simple"
 authors = [
     "Alec Gunny <alec.gunny@ligo.org>",
+    "Ethan Marx <emarx@mit.edu>"
 ]
 
 [tool.poetry.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ authors = [
     "Alec Gunny <alec.gunny@ligo.org>",
     "Ethan Marx <emarx@mit.edu>"
 ]
-
+packages = [
+    { include = "hermes" }
+]
 [tool.poetry.dependencies]
 python = ">=3.8,<3.11"
 


### PR DESCRIPTION
Branches off of commit https://github.com/ML4GW/hermes/commit/12e19f1887616ebb025846128e08e99e7338619e in support of #52.

Changes:
1. Adds pypi publishing workflow on releases
2. Changes package name to `ml4gw-hermes` since hermes is taken. 