### PR TITLE
More intelligent and flexible input and output tensor naming for `TorchScript` Exporter

### DIFF
--- a/hermes/quiver/exporters/exporter.py
+++ b/hermes/quiver/exporters/exporter.py
@@ -259,7 +259,8 @@ class Exporter(metaclass=abc.ABCMeta):
                 "Platform metaclass has no `handles` property"
             )
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def platform(self) -> "Platform":
         try:
             return type(self).platform

--- a/hermes/quiver/exporters/torch_onnx.py
+++ b/hermes/quiver/exporters/torch_onnx.py
@@ -21,7 +21,7 @@ class TorchOnnxMeta(abc.ABCMeta):
             raise ImportError(
                 "Must have torch installed to use TorchOnnx export platform"
             )
-        return torch.nn.Module
+        return (torch.nn.Module, torch.jit.ScriptModule)
 
     @property
     def platform(self):

--- a/hermes/quiver/exporters/torch_onnx.py
+++ b/hermes/quiver/exporters/torch_onnx.py
@@ -1,5 +1,4 @@
 import abc
-import inspect
 from collections import OrderedDict
 from io import BytesIO
 
@@ -12,14 +11,7 @@ except ImportError:
 
 from hermes.quiver import Platform
 from hermes.quiver.exporters import Exporter
-
-
-def get_input_names_from_script_module(m):
-    graph = m.graph
-    input_names = [node.debugName().split(".")[0] for node in graph.inputs()]
-    if "self" in input_names:
-        input_names.remove("self")
-    return OrderedDict({name: name for name in input_names})
+from hermes.quiver.exporters.utils import get_input_names_from_torch_object
 
 
 class TorchOnnxMeta(abc.ABCMeta):
@@ -63,14 +55,9 @@ class TorchOnnx(Exporter, metaclass=TorchOnnxMeta):
             # generate an input array of random data
             input_tensors[input.name] = self._get_tensor(input.dims)
 
-        # parse script module to figure out in which order
-        # to pass input tensors to the model_fn
-        if isinstance(model_fn, torch.jit.ScriptModule):
-            parameters = get_input_names_from_script_module(model_fn)
-        # otherwise use function signature from module.forward
-        else:
-            signature = inspect.signature(model_fn.forward)
-            parameters = OrderedDict(signature.parameters)
+        # parse either a `ScriptModule` or `torch.nn.Module`
+        # to figure out in which order to pass input tensors to the model_fn
+        parameters = get_input_names_from_torch_object(model_fn)
 
         # make sure the number of inputs to
         # the model_fn matches the number of

--- a/hermes/quiver/exporters/torchscript.py
+++ b/hermes/quiver/exporters/torchscript.py
@@ -1,5 +1,4 @@
 import abc
-import inspect
 from collections import OrderedDict
 from io import BytesIO
 
@@ -12,6 +11,7 @@ except ImportError:
 
 from hermes.quiver import Platform
 from hermes.quiver.exporters import Exporter
+from hermes.quiver.exporters.utils import get_input_names_from_torch_object
 
 
 class TorchScriptMeta(abc.ABCMeta):
@@ -66,11 +66,9 @@ class TorchScript(Exporter, metaclass=TorchScriptMeta):
             # generate an input array of random data
             input_tensors[input.name] = self._get_tensor(input.dims)
 
-        # use function signature from module.forward
-        # to figure out in which order to pass input
-        # tensors to the model_fn
-        signature = inspect.signature(model_fn.forward)
-        parameters = OrderedDict(signature.parameters)
+        # parse either a `ScriptModule` or `torch.nn.Module`
+        # to figure out in which order to pass input tensors to the model_fn
+        parameters = get_input_names_from_torch_object(model_fn)
 
         # make sure the number of inputs to
         # the model_fn matches the number of

--- a/hermes/quiver/exporters/torchscript.py
+++ b/hermes/quiver/exporters/torchscript.py
@@ -22,7 +22,7 @@ class TorchScriptMeta(abc.ABCMeta):
             raise ImportError(
                 "Must have torch installed to use TorchScript export platform"
             )
-        return torch.nn.Module
+        return (torch.nn.Module, torch.jit.ScriptModule)
 
     @property
     def platform(self):

--- a/hermes/quiver/exporters/utils.py
+++ b/hermes/quiver/exporters/utils.py
@@ -28,6 +28,9 @@ def find_exporter(
         model_fn:
             The framework-specific function which performs the
             neural network's input/output mapping
+        model:
+            The `Model` object which specifies the desired export platform
+            and configuration information for the model
     Returns:
         An exporter to export `model_fn` to the format specified
         by this models' inference platform
@@ -65,7 +68,7 @@ def find_exporter(
 
 
 def get_input_names_from_torch_object(
-    model_fn: Union["torch.nn.Module", "torch.ScriptModule"]
+    model_fn: Union["torch.nn.Module", "torch.jit.ScriptModule"]
 ):
     """
     Parse either a torch.nn.Module or torch.ScriptModule for input names

--- a/hermes/quiver/exporters/utils.py
+++ b/hermes/quiver/exporters/utils.py
@@ -2,9 +2,14 @@ import inspect
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Callable, Union
 
-import torch
-
 from .exporter import Exporter
+
+try:
+    import torch
+
+    _has_torch = True
+except ImportError:
+    _has_torch = False
 
 if TYPE_CHECKING:
     from hermes.quiver.model import Model
@@ -60,11 +65,12 @@ def find_exporter(
 
 
 def get_input_names_from_torch_object(
-    model_fn: Union[torch.nn.Module, torch.ScriptModule]
+    model_fn: Union["torch.nn.Module", "torch.ScriptModule"]
 ):
     """
     Parse either a torch.nn.Module or torch.ScriptModule for input names
     """
+
     if isinstance(model_fn, torch.jit.ScriptModule):
         graph = model_fn.graph
         input_names = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -2520,6 +2520,7 @@ description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs 
 optional = true
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
     {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
 ]
 
@@ -2530,6 +2531,7 @@ description = "A collection of ASN.1-based protocols modules"
 optional = true
 python-versions = ">=3.8"
 files = [
+    {file = "pyasn1_modules-0.4.1-py3-none-any.whl", hash = "sha256:49bfa96b45a292b711e986f222502c1c9a5e1f4e568fc30e2574a6c7d07838fd"},
     {file = "pyasn1_modules-0.4.1.tar.gz", hash = "sha256:c28e2dbf9c06ad61c71a075c7e0f9fd0f1b0bb2d2ad4377f240d33ac2ab60a7c"},
 ]
 
@@ -3369,11 +3371,6 @@ files = [
     {file = "triton-3.0.0-1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:34e509deb77f1c067d8640725ef00c5cbfcb2052a1a3cb6a6d343841f92624eb"},
     {file = "triton-3.0.0-1-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bcbf3b1c48af6a28011a5c40a5b3b9b5330530c3827716b5fbf6d7adcc1e53e9"},
     {file = "triton-3.0.0-1-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6e5727202f7078c56f91ff13ad0c1abab14a0e7f2c87e91b12b6f64f3e8ae609"},
-    {file = "triton-3.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39b052da883351fdf6be3d93cedae6db3b8e3988d3b09ed221bccecfa9612230"},
-    {file = "triton-3.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd34f19a8582af96e6291d4afce25dac08cb2a5d218c599163761e8e0827208e"},
-    {file = "triton-3.0.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d5e10de8c011adeb7c878c6ce0dd6073b14367749e34467f1cff2bde1b78253"},
-    {file = "triton-3.0.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8903767951bf86ec960b4fe4e21bc970055afc65e9d57e916d79ae3c93665e3"},
-    {file = "triton-3.0.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:41004fb1ae9a53fcb3e970745feb87f0e3c94c6ce1ba86e95fa3b8537894bef7"},
 ]
 
 [package.dependencies]

--- a/tests/quiver/conftest.py
+++ b/tests/quiver/conftest.py
@@ -97,3 +97,19 @@ def torch_model(dim):
             return torch.matmul(x, self.W)
 
     return Model(dim)
+
+
+@pytest.fixture
+def torch_model_2(dim):
+    import torch
+
+    class Model(torch.nn.Module):
+        def __init__(self, size: int = 10):
+            super().__init__()
+            self.size = size
+            self.W = torch.eye(size)
+
+        def forward(self, x, y):
+            return torch.matmul(x, self.W), y
+
+    return Model(dim)

--- a/tests/quiver/exporters/test_exporter_utils.py
+++ b/tests/quiver/exporters/test_exporter_utils.py
@@ -2,7 +2,12 @@ from unittest.mock import Mock
 
 import pytest
 
-from hermes.quiver.exporters import KerasSavedModel, TorchOnnx, utils
+from hermes.quiver.exporters import (
+    KerasSavedModel,
+    TorchOnnx,
+    TorchScript,
+    utils,
+)
 from hermes.quiver.platform import Platform
 
 
@@ -33,3 +38,12 @@ def test_find_torch_exporter(torch_model):
     good_model = make_model(Platform.ONNX)
     bad_model = make_model(Platform.SAVEDMODEL)
     _test_find_exporter(torch_model, good_model, bad_model, TorchOnnx)
+
+    good_model = make_model(Platform.TORCHSCRIPT)
+    _test_find_exporter(torch_model, good_model, bad_model, TorchScript)
+
+    import torch
+
+    script_module = torch.jit.trace(torch_model, torch.randn(1, 10))
+    good_model = make_model(Platform.TORCHSCRIPT)
+    _test_find_exporter(script_module, good_model, bad_model, TorchScript)

--- a/tests/quiver/exporters/test_torchscript.py
+++ b/tests/quiver/exporters/test_torchscript.py
@@ -5,16 +5,16 @@ from hermes.quiver.exporters import TorchScript
 
 
 @pytest.mark.torch
-def test_torchscript_exporter(temp_local_repo, torch_model):
+def test_torchscript_exporter(temp_local_repo, torch_model, torch_model_2):
     model_fn = torch_model
 
     model = Model("identity", temp_local_repo, Platform.TORCHSCRIPT)
     exporter = TorchScript(model.config, model.fs)
 
-    input_shapes = {"x": (None, 10)}
+    input_shapes = {"input0": (None, 10)}
     exporter._check_exposed_tensors("input", input_shapes)
     assert len(model.config.input) == 1
-    assert model.config.input[0].name == "x"
+    assert model.config.input[0].name == "input0"
     assert model.config.input[0].dims[0] == -1
 
     bad_input_shapes = {"x": (None, 12)}
@@ -22,11 +22,11 @@ def test_torchscript_exporter(temp_local_repo, torch_model):
         exporter._check_exposed_tensors("input", bad_input_shapes)
 
     output_shapes = exporter._get_output_shapes(model_fn, "y")
-    assert output_shapes["OUTPUT__0"] == (None, 10)
+    assert output_shapes["y"] == (None, 10)
 
     exporter._check_exposed_tensors("output", output_shapes)
     assert len(model.config.output) == 1
-    assert model.config.output[0].name == "OUTPUT__0"
+    assert model.config.output[0].name == "y"
     assert model.config.output[0].dims[0] == -1
 
     version_path = temp_local_repo.fs.join("identity", "1")
@@ -39,8 +39,67 @@ def test_torchscript_exporter(temp_local_repo, torch_model):
     exporter = TorchScript(model2.config, model2.fs)
 
     model_path = temp_local_repo.fs.root
-    with pytest.raises(ValueError):
-        exporter(model_fn, model_path, [(None, 10)], ["BAD_NAME"])
+
+    # if a dictionary if input_shapes is not passed
+    # (i.e. no user specified name) it should default
+    # to the name of the input tensor in the forward call of the model
+    # in this case, "x"
     exporter(model_fn, model_path, [(None, 10)])
-    assert "INPUT__0" in model2.inputs
+    assert "x" in model2.inputs
     assert "OUTPUT__0" in model2.outputs
+
+    # if a dictionary of input_shapes is passed, it should
+    # use the user specified names
+    model3 = Model("identity3", temp_local_repo, Platform.TORCHSCRIPT)
+    exporter = TorchScript(model3.config, model3.fs)
+    model_path = temp_local_repo.fs.root
+
+    exporter(model_fn, model_path, input_shapes={"my_name": (None, 10)})
+    assert "my_name" in model3.inputs
+    assert "OUTPUT__0" in model3.outputs
+
+    # now check using non-default output names
+    model4 = Model("identity4", temp_local_repo, Platform.TORCHSCRIPT)
+    exporter = TorchScript(model4.config, model4.fs)
+    model_path = temp_local_repo.fs.root
+
+    exporter(
+        model_fn,
+        model_path,
+        input_shapes={"my_name": (None, 10)},
+        output_names=["my_output"],
+    )
+    assert "my_name" in model4.inputs
+    assert "my_output" in model4.outputs
+
+    # test a model with multiple inputs and outputs
+    model_fn = torch_model_2
+
+    model = Model("identity", temp_local_repo, Platform.TORCHSCRIPT)
+    exporter = TorchScript(model.config, model.fs)
+
+    input_shapes = {"input0": (None, 10), "input1": (None, 10)}
+    exporter._check_exposed_tensors("input", input_shapes)
+    assert len(model.config.input) == 2
+    assert model.config.input[0].name == "input0"
+    assert model.config.input[1].name == "input1"
+    assert model.config.input[0].dims[0] == -1
+    assert model.config.input[1].dims[0] == -1
+
+    bad_input_shapes = {"x": (None, 12)}
+    with pytest.raises(ValueError):
+        exporter._check_exposed_tensors("input", bad_input_shapes)
+
+    output_shapes = exporter._get_output_shapes(
+        model_fn, ["output1", "output2"]
+    )
+    assert output_shapes["output1"] == (None, 10)
+    assert output_shapes["output2"] == (None, 10)
+
+    model4 = Model("identity4", temp_local_repo, Platform.TORCHSCRIPT)
+    exporter = TorchScript(model4.config, model4.fs)
+    model_path = temp_local_repo.fs.root
+
+    exporter(model_fn, model_path, input_shapes=[(None, 10), (None, 10)])
+    assert "x" in model4.inputs and "y" in model4.inputs
+    assert "OUTPUT__0" in model4.outputs and "OUTPUT__1" in model4.outputs


### PR DESCRIPTION
Previously, the `TorchScript` exporter directly enforced input and output tensor names follow the `INPUT__{i}` `OUTPUT__{i}` convention. The main reason for this is that triton expects certain naming conventions to deal with the fact that TorchScript models don't come with some necessary metadata triton needs to match input tensors to the appropriate ordering expected by the model. If your model only has one input and one output, this detail is irrelevant, and any naming will work. 

This convention is not the only way to deal with this (see [here](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/model_configuration.html#special-conventions-for-pytorch-backend)): one can also name the tensors by the parameter names in the models `forward`, or name the tensors with `<name>__<index>`.

In any case, the `INPUT__{i}` `OUTPUT__{i}` tensor naming enforcement was leading to some difficulties when ensembling multiple torchscript models due to conflicting tensor names.

This PR makes naming tensors in `TorchScript` models more flexible by doing the following:

- Input tensors

  1. If the user passes a dictionary of `{tensor_name: shape}` for the `input_shapes`, the user passed names will be used. A warning will be given telling users to be careful when using their own name. 
  2. If the user passes a `List[shape]`  to `input_shapes`, the names will be inferred directly from the `forward` method of the `TorchScript` model - this behavior is recommended by triton.

- Output tensors
   1. If the user passes a `List[name]`  to `output_names`, the user passed names will be used
   2. If `output_names` is left as `None`, the `OUTPUT__{i}` convention will be used



