### PR TITLE
Implemented workaround for is_server_alive checking

### DIFF
--- a/hermes/aeriel/serve/serve.py
+++ b/hermes/aeriel/serve/serve.py
@@ -64,13 +64,15 @@ def get_wait(q: Queue, log_file: Optional[str] = None):
         timeout: Optional[float] = None,
         log_interval: float = 10,
     ) -> None:
-        client = triton.InferenceServerClient(endpoint)
         logging.info("Waiting for server to come online")
 
         timer = Timer(timeout, log_interval)
         live = False
         while timer.tick():
             try:
+                # Re-define the client on each loop
+                # See https://github.com/ML4GW/hermes/issues/71
+                client = triton.InferenceServerClient(endpoint)
                 live = client.is_server_live()
             except triton.InferenceServerException:
                 pass


### PR DESCRIPTION
Closes #71.

@EthanMarx I tried versions of `tritonclient` between v2.30.0 and v2.51.0, which is the extent that we can cover with version limitations on tensorflow. The bug was present in all of them, so it seems like something changed at a lower level. Given that this is a breaking bug, I think we should get this workaround in and make a release.